### PR TITLE
Unread status for channels

### DIFF
--- a/app/components/channel-container/component.js
+++ b/app/components/channel-container/component.js
@@ -1,5 +1,15 @@
 import Ember from 'ember';
 
+function scrollToBottom() {
+  Ember.$('#channel-content').animate({
+    scrollTop: Ember.$('#channel-content ul').height()
+  }, '500');
+}
+
+function focusMessageInput() {
+  Ember.$('input#message-field').focus();
+}
+
 export default Ember.Component.extend({
 
   elementId: 'channel',
@@ -30,13 +40,3 @@ export default Ember.Component.extend({
 
   }
 });
-
-function scrollToBottom() {
-  Ember.$('#channel-content').animate({
-    scrollTop: Ember.$('#channel-content ul').height()
-  }, '500');
-}
-
-function focusMessageInput() {
-  Ember.$('input#message-field').focus();
-}

--- a/app/components/channel-nav/template.hbs
+++ b/app/components/channel-nav/template.hbs
@@ -3,7 +3,7 @@
     <h2>{{#link-to "space" space}}{{space.name}}{{/link-to}}</h2>
     <ul>
     {{#each space.sortedChannels as |channel|}}
-      <li class="{{if channel.connected "connected" "disconnected"}}">
+      <li class="{{if channel.connected "connected" "disconnected"}} {{channel.unreadMessagesClass}}">
         {{#if channel.isUserChannel}}
           {{#link-to "space.userChannel" space channel}}{{channel.name}}{{/link-to}}
         {{else}}

--- a/app/models/channel.js
+++ b/app/models/channel.js
@@ -8,6 +8,9 @@ export default Ember.Object.extend({
   connected: false,
   sockethubChannelId: null,
   topic: null,
+  unreadMessages: false,
+  unreadMentions: false,
+  visible: false, // Current/active channel
 
   slug: function() {
     // This could be based on server type in the future. E.g. IRC would be
@@ -25,6 +28,13 @@ export default Ember.Object.extend({
     } else {
       return '';
     }
-  }.property('topic')
+  }.property('topic'),
+
+  unreadMessagesClass: function() {
+    if (this.get('visible') || !this.get('unreadMessages')) {
+      return null;
+    }
+    return this.get('unreadMentions') ? 'unread-mentions' : 'unread-messages';
+  }.property('visible', 'unreadMessages', 'unreadMentions')
 
 });

--- a/app/routes/space/base_channel.js
+++ b/app/routes/space/base_channel.js
@@ -4,16 +4,18 @@ export default Ember.Route.extend({
 
   smt: Ember.inject.service(),
 
-  model: function(params) {
+  model(params) {
     var space = this.modelFor('space');
     var channel = space.get('channels').findBy('slug', params.slug);
+
     if (!channel) {
       channel = this.createChannelOrUserChannel(space, params.slug);
     }
+
     return channel;
   },
 
-  setupController: function(controller, model) {
+  setupController(controller, model) {
     this._super(controller, model);
 
     Ember.run.scheduleOnce('afterRender', function() {
@@ -22,6 +24,23 @@ export default Ember.Route.extend({
         scrollTop: Ember.$('#channel-content ul').height()
       }, '500');
     });
+  },
+
+  actions: {
+
+    didTransition() {
+      let space = this.modelFor('space');
+      let channel = this.controller.get('model');
+
+      // Mark channel as active/visible
+      space.get('channels').setEach('visible', false);
+      channel.set('visible', true);
+
+      // Mark unread messages as read
+      channel.set('unreadMessages', false);
+      channel.set('unreadMentions', false);
+    }
+
   }
 
 });

--- a/app/routes/space/channel.js
+++ b/app/routes/space/channel.js
@@ -1,7 +1,9 @@
 import BaseChannel from 'hyperchannel/routes/space/base_channel';
 
 export default BaseChannel.extend({
+
   createChannelOrUserChannel: function(space, channelName){
     return this.get('smt').createChannel(space, "#" + channelName);
   }
+
 });

--- a/app/services/smt.js
+++ b/app/services/smt.js
@@ -263,7 +263,9 @@ export default Ember.Service.extend({
 
       if (!channel.get('visible')) {
         channel.set('unreadMessages', true);
-        // TODO set unread mentions
+        if (message.object.content.match(nickname)) {
+          channel.set('unreadMentions', true);
+        }
       }
     }
   },

--- a/app/services/smt.js
+++ b/app/services/smt.js
@@ -216,6 +216,8 @@ export default Ember.Service.extend({
 
       // channel.get('messages').pushObject(notification);
 
+      // TODO only send when topic actually changed (and not after joining
+      // channels)
       Notification.requestPermission(function(){
         new Notification(channel.name, {
           body: "New Topic: " + message.object.topic

--- a/app/services/smt.js
+++ b/app/services/smt.js
@@ -399,8 +399,10 @@ export default Ember.Service.extend({
           },
           channels: [
             '#67p',
+            '#hackerbeach',
             '#kosmos',
             '#kosmos-dev',
+            '#kosmos-random',
             '#sockethub'
           ],
       },

--- a/app/services/smt.js
+++ b/app/services/smt.js
@@ -207,12 +207,12 @@ export default Ember.Service.extend({
 
       channel.set('topic', message.object.topic);
 
-      Message.create({
-        type: 'notification-topic-change',
-        date: new Date(message.published),
-        nickname: message.actor.displayName,
-        content: message.object.topic
-      });
+      // let notification = Message.create({
+      //   type: 'notification-topic-change',
+      //   date: new Date(message.published),
+      //   nickname: message.actor.displayName,
+      //   content: message.object.topic
+      // });
 
       // channel.get('messages').pushObject(notification);
 

--- a/app/services/smt.js
+++ b/app/services/smt.js
@@ -260,6 +260,11 @@ export default Ember.Service.extend({
     // TODO should check for message and update sent status if exists
     if (message.actor.displayName !== nickname) {
       channel.get('messages').pushObject(channelMessage);
+
+      if (!channel.get('visible')) {
+        channel.set('unreadMessages', true);
+        // TODO set unread mentions
+      }
     }
   },
 

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -218,5 +218,6 @@ header {
 
 @import "layout";
 @import "iconfont";
+@import "components/channel-nav";
 @import "components/message-chat";
 @import "components/notification-topic-change";

--- a/app/styles/components/channel-nav.scss
+++ b/app/styles/components/channel-nav.scss
@@ -1,0 +1,18 @@
+nav#channels {
+
+  ul {
+    li {
+      &.unread-messages {
+        a {
+          color: lightblue;
+        }
+      }
+      &.unread-mentions {
+        a {
+          color: yellow;
+        }
+      }
+    }
+  }
+
+}

--- a/tests/unit/models/channel-test.js
+++ b/tests/unit/models/channel-test.js
@@ -14,6 +14,10 @@ test('#slug', function(assert) {
   assert.ok(model.get('slug') === 'kosmos-dev');
 });
 
+//
+// formattedTopic
+//
+
 test('#formattedTopic turns URLs into links', function(assert) {
   var channel = this.subject();
   channel.set('topic', 'visit kosmos.org for more info');
@@ -26,4 +30,42 @@ test('#formattedTopic escapes HTML', function(assert) {
   channel.set('topic', 'never gonna <marquee>give you up</marquee>');
 
   assert.equal(channel.get('formattedTopic').toString(), 'never gonna &lt;marquee&gt;give you up&lt;/marquee&gt;');
+});
+
+//
+// unreadMessagesClass
+//
+
+test('#unreadMessagesClass is null when channel is visible', function(assert) {
+  var channel = this.subject();
+  channel.set('unreadMessages', true);
+  channel.set('visible', true);
+
+  assert.equal(channel.get('unreadMessagesClass'), null);
+});
+
+test('#unreadMessagesClass is null when channel has no unread messages', function(assert) {
+  var channel = this.subject();
+  channel.set('unreadMessages', false);
+  channel.set('visible', false);
+
+  assert.equal(channel.get('unreadMessagesClass'), null);
+});
+
+test('#unreadMessagesClass is correct for unread messages', function(assert) {
+  var channel = this.subject();
+  channel.set('unreadMessages', true);
+  channel.set('unreadMentions', false);
+  channel.set('visible', false);
+
+  assert.equal(channel.get('unreadMessagesClass'), 'unread-messages');
+});
+
+test('#unreadMessagesClass is correct for unread mentions', function(assert) {
+  var channel = this.subject();
+  channel.set('unreadMessages', true);
+  channel.set('unreadMentions', true);
+  channel.set('visible', false);
+
+  assert.equal(channel.get('unreadMessagesClass'), 'unread-mentions');
 });


### PR DESCRIPTION
This adds a visibility status to channels, and marks them as unread when new messages arrive, while they're not visible.

Connected to #46 