### PR TITLE
Add remoteStorage 1.0.0-beta from npm module

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -7,6 +7,9 @@ let App;
 
 Ember.MODEL_FACTORY_INJECTIONS = true;
 
+Ember.deprecate = function(){};
+Ember.warn = function(){};
+
 App = Ember.Application.extend({
   modulePrefix: config.modulePrefix,
   podModulePrefix: config.podModulePrefix,

--- a/app/app.js
+++ b/app/app.js
@@ -11,6 +11,7 @@ Ember.deprecate = function(){};
 Ember.warn = function(){};
 
 App = Ember.Application.extend({
+  LOG_TRANSITIONS: true,
   modulePrefix: config.modulePrefix,
   podModulePrefix: config.podModulePrefix,
   Resolver

--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -1,12 +1,17 @@
-import Ember   from 'ember';
+import Ember from 'ember';
 
 export default Ember.Controller.extend({
 
   smt: Ember.inject.service(),
+  storage: Ember.inject.service('remotestorage'),
   spaces: Ember.computed.alias('smt.spaces'),
+
+  // Make the RS instance available in the browser console for development
+  setRemoteStorageGlobal: function() {
+    window.remoteStorage = this.get('storage.rs');
+  }.on('init'),
 
   showGlobalMenu: false,
   showChannelMenu: false
 
 });
-

--- a/app/controllers/settings.js
+++ b/app/controllers/settings.js
@@ -3,6 +3,7 @@ import Ember from 'ember';
 export default Ember.Controller.extend({
 
   application: Ember.inject.controller(),
-  ircSettings: Ember.computed.alias('application.ircSettings')
+
+  newSpace: null,
 
 });

--- a/app/controllers/space/base_channel.js
+++ b/app/controllers/space/base_channel.js
@@ -43,7 +43,7 @@ export default Ember.Controller.extend({
       if (availableCommands.includes(command.toLowerCase())) {
         this.send(command + 'Command', commandSplitted.slice(1));
       } else {
-        console.log('Unknown command', commandText);
+        Ember.Logger.warn('[channel]', 'Unknown command', commandText);
       }
 
       this.set('newMessage', null);

--- a/app/controllers/space/base_channel.js
+++ b/app/controllers/space/base_channel.js
@@ -12,7 +12,7 @@ export default Ember.Controller.extend({
       let message = Message.create({
         type: 'message-chat',
         date: new Date(),
-        nickname: this.get('space.model.ircServer.nickname'),
+        nickname: this.get('space.model.server.nickname'),
         content: newMessage
       });
 
@@ -75,7 +75,7 @@ export default Ember.Controller.extend({
       let message = Message.create({
         type: 'message-chat-me',
         date: new Date(),
-        nickname: this.get('space.model.ircServer.nickname'),
+        nickname: this.get('space.model.server.nickname'),
         content: newMessage
       });
 

--- a/app/initializers/remotestorage.js
+++ b/app/initializers/remotestorage.js
@@ -1,0 +1,20 @@
+import Ember from 'ember';
+
+export default {
+  name: 'remotestorage',
+  storage: Ember.inject.service('remotestorage'),
+  initialize(/* application */) {
+    // let rs = this.get('storage.rs');
+    //
+    // let rsEvents = [
+    //   'ready', 'not-connected', 'connected', 'disconnected', 'error',
+    //   'features-loaded', 'connecting', 'authing', 'wire-busy', 'wire-done',
+    //   'network-offline', 'network-online'
+    // ];
+    //
+    // rsEvents.forEach(evt => {
+    //   rs.on(evt, () => console.debug(`rs ${evt}`));
+    // });
+  }
+};
+

--- a/app/models/space.js
+++ b/app/models/space.js
@@ -6,8 +6,8 @@ export default Ember.Object.extend({
   protocol  : 'IRC',
   server : {
     hostname: null,
-    port: 6667,
-    secure: false,
+    port: 7000,
+    secure: true,
     username: null,
     password: null,
     nickname: null,
@@ -15,8 +15,9 @@ export default Ember.Object.extend({
       password: null
     }
   },
-  channels  : null,
-  users     : null,
+  channels   : null, // Channel instances
+  channelList: [],   // Bookmarked channel names
+  users      : null,
 
   id: function() {
     // This could be based on server type in the future. E.g. IRC would be
@@ -33,15 +34,6 @@ export default Ember.Object.extend({
   channelSorting: ['name'],
   sortedChannels: Ember.computed.sort('channels', 'channelSorting'),
 
-  addChannel(channel) {
-    this.get('channels').pushObject(channel);
-  },
-
-  channelNames: function() {
-    if (Ember.isEmpty(this.get('channels'))) { return []; }
-    return this.get('channels').mapBy('channelName');
-  }.property('channels.[]'),
-
   serialize() {
     return {
       id: this.get('id'),
@@ -50,9 +42,10 @@ export default Ember.Object.extend({
       server: {
         hostname: this.get('server.hostname'),
         port: parseInt(this.get('server.port')),
+        secure: this.get('server.secure'),
         nickname: this.get('server.nickname'),
       },
-      channels: this.get('channelNames')
+      channels: this.get('channelList')
     };
   },
 

--- a/app/models/space.js
+++ b/app/models/space.js
@@ -2,9 +2,10 @@ import Ember from 'ember';
 
 export default Ember.Object.extend({
 
-  name      : '',
-  ircServer : {
-    hostname: 'irc.freenode.net',
+  name      : null,
+  protocol  : 'IRC',
+  server : {
+    hostname: null,
     port: 6667,
     secure: false,
     username: null,
@@ -23,17 +24,36 @@ export default Ember.Object.extend({
     return this.get('name').toLowerCase();
   }.property('name'),
 
-  userNickname: Ember.computed.alias('ircServer.nickname'),
+  userNickname: Ember.computed.alias('server.nickname'),
 
   sockethubPersonId: function() {
-    return `irc://${this.get('ircServer.nickname')}@${this.get('ircServer.hostname')}`;
-  }.property('ircServer.hostname', 'ircServer.nickname'),
+    return `irc://${this.get('server.nickname')}@${this.get('server.hostname')}`;
+  }.property('server.hostname', 'server.nickname'),
 
   channelSorting: ['name'],
   sortedChannels: Ember.computed.sort('channels', 'channelSorting'),
 
   addChannel(channel) {
     this.get('channels').pushObject(channel);
-  }
+  },
+
+  channelNames: function() {
+    if (Ember.isEmpty(this.get('channels'))) { return []; }
+    return this.get('channels').mapBy('channelName');
+  }.property('channels.[]'),
+
+  serialize() {
+    return {
+      id: this.get('id'),
+      name: this.get('name'),
+      protocol: this.get('protocol'),
+      server: {
+        hostname: this.get('server.hostname'),
+        port: parseInt(this.get('server.port')),
+        nickname: this.get('server.nickname'),
+      },
+      channels: this.get('channelNames')
+    };
+  },
 
 });

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import { storageFor as localStorageFor } from 'ember-local-storage';
 
 const {
   Route,
@@ -9,9 +10,20 @@ const {
 
 export default Route.extend({
   smt: service(),
+  userSettings: localStorageFor('user-settings'),
 
   model() {
-    this.get('smt').loadFixtures();
+    this.get('smt').setupListeners();
+    return this.get('smt').instantiateSpacesAndChannels();
+  },
+
+  afterModel() {
+    let currentSpace = this.get('userSettings.currentSpace') || 'freenode';
+    let currentChannel = this.get('userSettings.currentChannel') || '#kosmos';
+
+    if (currentSpace && currentChannel) {
+      this.transitionTo('space.channel', currentSpace, currentChannel);
+    }
   },
 
   actions: {

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -1,19 +1,4 @@
 import Ember from 'ember';
-import { storageFor as localStorageFor } from 'ember-local-storage';
 
-const {
-  Route
-} = Ember;
-
-export default Route.extend({
-  userSettings: localStorageFor('user-settings'),
-
-  beforeModel() {
-    let currentSpace = this.get('userSettings.currentSpace');
-    let currentChannel = this.get('userSettings.currentChannel');
-
-    if (currentSpace && currentChannel) {
-      this.transitionTo('space.channel', currentSpace, currentChannel);
-    }
-  }
+export default Ember.Route.extend({
 });

--- a/app/routes/settings.js
+++ b/app/routes/settings.js
@@ -43,7 +43,7 @@ export default Ember.Route.extend({
         .then((/*d*/) => {
             this.modelFor('settings').spaces.pushObject(newSpace);
           }, e => {
-            console.log('error saving in RS', e, params);
+            Ember.Logger.error('error saving in RS', params, e);
           }
         );
     },
@@ -54,8 +54,7 @@ export default Ember.Route.extend({
         .then((/*d*/) => {
             this.modelFor('settings').spaces.removeObject(space);
           }, e => {
-            Ember.Logger.debug('error deleting from RS', space);
-            console.error(e);
+            Ember.Logger.error('error deleting from RS', space, e);
           }
         );
     }

--- a/app/routes/settings.js
+++ b/app/routes/settings.js
@@ -1,14 +1,65 @@
 import Ember from 'ember';
+import Space from 'hyperchannel/models/space';
 
 export default Ember.Route.extend({
 
+  storage: Ember.inject.service('remotestorage'),
+
+  model() {
+    let rsKosmos = this.get('storage.rs').kosmos;
+
+    let spaces = rsKosmos.spaces.getAll().then(
+      res => {
+        let col = [];
+        if (Ember.isEmpty(res)) { return col; }
+        Object.keys(res).forEach(id => {
+          col.push(Space.create(res[id]));
+        });
+        return col;
+      },
+      e => {
+        console.error(e);
+      }
+    );
+
+    return Ember.RSVP.hash({
+      // TODO use space models
+      spaces: spaces
+    });
+  },
+
+  setupController(controller) {
+    this._super(...arguments);
+    controller.set('newSpace', Space.create());
+  },
+
   actions: {
-    save: function() {
-      var settings = this.controller.get('ircSettings');
-      window.localStorage.setItem('hyperchannel:irc_settings', JSON.stringify(settings));
-      console.log('saved settings', settings);
-      this.controllerFor('application').configureIRC();
+
+    addSpace() {
+      let newSpace = this.controller.get('newSpace');
+      let params   = newSpace.serialize();
+
+      this.get('storage.rs').kosmos.spaces.store(params)
+        .then((/*d*/) => {
+            this.modelFor('settings').spaces.pushObject(newSpace);
+          }, e => {
+            console.log('error saving in RS', e, params);
+          }
+        );
+    },
+
+    removeSpace(space) {
+      // TODO this is buggy in the current rs.js beta branch
+      this.get('storage.rs').kosmos.spaces.remove(space.get('id'))
+        .then((/*d*/) => {
+            this.modelFor('settings').spaces.removeObject(space);
+          }, e => {
+            Ember.Logger.debug('error deleting from RS', space);
+            console.error(e);
+          }
+        );
     }
+
   }
 
 });

--- a/app/routes/space/base_channel.js
+++ b/app/routes/space/base_channel.js
@@ -20,7 +20,6 @@ function scrollToBottom() {
 
 function focusMessageInput() {
   if (window.innerWidth > 900) {
-    console.debug('innerWidth', window.innerWidth);
     Ember.$('input#message-field').focus();
   } else {
     // Don't auto-focus on small screens

--- a/app/services/remotestorage.js
+++ b/app/services/remotestorage.js
@@ -1,0 +1,12 @@
+import Ember from 'ember';
+import RemoteStorage from 'npm:remotestoragejs';
+
+export default Ember.Service.extend({
+
+  rsInstance: null,
+
+  rs: function() {
+    return this.get('rsInstance') || new RemoteStorage({logging: true});
+  }.property('rs')
+
+});

--- a/app/services/remotestorage.js
+++ b/app/services/remotestorage.js
@@ -1,12 +1,29 @@
 import Ember from 'ember';
 import RemoteStorage from 'npm:remotestoragejs';
+import 'npm:remotestorage-module-kosmos';
 
 export default Ember.Service.extend({
 
   rsInstance: null,
 
   rs: function() {
-    return this.get('rsInstance') || new RemoteStorage({logging: true});
-  }.property('rs')
+    let rs = this.get('rsInstance') || new RemoteStorage(/* {logging: true} */);
+    rs.access.claim('kosmos', 'rw');
+    rs.caching.enable('/kosmos/');
+    return rs;
+  }.property('rs'),
+
+  addDefaultSpace() {
+    this.get('rs').kosmos.spaces.store({
+      id: 'freenode',
+      name: 'Freenode',
+      protocol: 'IRC',
+      server: {
+        hostname: 'irc.freenode.net',
+        port: 6667
+      },
+      channels: ['#hackerbeach','#kosmos','#kosmos-dev','#kosmos-random','#sockethub']
+    }).then(d => console.debug('data', d), e => console.debug('error', e));
+  }
 
 });

--- a/app/services/smt.js
+++ b/app/services/smt.js
@@ -9,7 +9,6 @@ import { storageFor as localStorageFor } from 'ember-local-storage';
 
 const {
   Service,
-  computed,
   inject: {
     service
   }
@@ -18,28 +17,42 @@ const {
 export default Service.extend({
   userSettings: localStorageFor('user-settings'),
   ajax: service(),
+  storage: service('remotestorage'),
 
   spaces: null,
-  // users:  null,
 
-  loadFixtures() {
-    this.setupListeners();
-    this.instantiateSpaces();
-    this.instantiateChannels();
-  },
-
-  instantiateSpaces() {
+  instantiateSpacesAndChannels() {
     this.set('spaces', []);
+    let rs = this.get('storage.rs');
 
-    var spaceFixtures = this.get('spaceFixtures');
-    Object.keys(spaceFixtures).forEach((spaceName) => {
-      var space = Space.create({
-        name: spaceName,
-        protocol: 'irc',
-        server: spaceFixtures[spaceName].server
+    return new Ember.RSVP.Promise((resolve, reject) => {
+      rs.kosmos.spaces.getAll().then(spaceData => {
+        if (Ember.isEmpty(Object.keys(spaceData))) {
+          Ember.Logger.debug('No space data found in RS. Adding default space...');
+          this.get('storage').addDefaultSpace().then((space) => {
+            this.connectToIRCServer(space);
+            this.get('spaces').pushObject(space);
+            this.instantiateChannels();
+            resolve();
+          });
+        } else {
+          Object.keys(spaceData).forEach((id) => {
+            let space = Space.create({
+              name: spaceData[id].name,
+              protocol: spaceData[id].protocol,
+              server: spaceData[id].server,
+              channelList: spaceData[id].channels
+            });
+            this.connectToIRCServer(space);
+            this.get('spaces').pushObject(space);
+          });
+          this.instantiateChannels();
+          resolve();
+        }
+      }, e => {
+        this.log('error', 'couldn\'d load spaces from RS', e);
+        reject();
       });
-      this.connectToIRCServer(space);
-      this.get('spaces').pushObject(space);
     });
   },
 
@@ -62,7 +75,7 @@ export default Service.extend({
       }
     };
 
-    // Ember.Logger.debug('connecting to irc', credentials);
+    Ember.Logger.debug('connecting to irc', credentials);
     this.sockethub.socket.emit('credentials', credentials);
   },
 
@@ -78,7 +91,7 @@ export default Service.extend({
       }
     };
 
-    // console.log('sending message job', job);
+    console.log('sending message job', job);
     this.sockethub.socket.emit('message', job);
   },
 
@@ -94,13 +107,13 @@ export default Service.extend({
       }
     };
 
-    // console.log('sending message job', job);
+    console.log('sending message job', job);
     this.sockethub.socket.emit('message', job);
   },
 
   setupListeners() {
     this.sockethub.socket.on('completed', (message) => {
-      // Ember.Logger.debug('SH completed', message);
+      Ember.Logger.debug('SH completed', message);
 
       switch(message['@type']) {
         case 'join':
@@ -124,7 +137,7 @@ export default Service.extend({
     });
 
     this.sockethub.socket.on('message', (message) => {
-      // Ember.Logger.debug('SH message', message);
+      Ember.Logger.debug('SH message', message);
 
       switch(message['@type']) {
         case 'observe':
@@ -292,7 +305,7 @@ export default Service.extend({
       }
     };
 
-    // Ember.Logger.debug('asking for attendance list', observeMsg);
+    Ember.Logger.debug('asking for attendance list', observeMsg);
     this.sockethub.socket.emit('message', observeMsg);
   },
 
@@ -300,7 +313,7 @@ export default Service.extend({
     this.get('spaces').forEach((space) => {
       space.set('channels', []);
 
-      this.get('spaceFixtures')[space.get('name')].channels.forEach((channelName) => {
+      space.get('channelList').forEach((channelName) => {
         this.createChannel(space, channelName);
       });
     });
@@ -315,7 +328,7 @@ export default Service.extend({
       userList: []
     });
     this.joinChannel(space, channel, "room");
-    space.addChannel(channel);
+    space.get('channels').pushObject(channel);
 
     this.loadArchiveMessages(space, channel);
 
@@ -332,7 +345,7 @@ export default Service.extend({
       dataType: 'json'
     }).then(archive => {
       Ember.get(archive, 'today.messages').forEach((message) => {
-        // console.log('message', message);
+        console.log('message', message);
         let channelMessage = Message.create({
           type: 'message-chat',
           date: new Date(message.timestamp),
@@ -343,7 +356,7 @@ export default Service.extend({
         channel.addMessage(channelMessage);
       });
     }, error => {
-      // console.log(error);
+      console.log(error);
     });
   },
 
@@ -381,7 +394,7 @@ export default Service.extend({
       object: {}
     };
 
-    // Ember.Logger.debug('joining channel', joinMsg);
+    Ember.Logger.debug('joining channel', joinMsg);
     this.sockethub.socket.emit('message', joinMsg);
   },
 
@@ -400,7 +413,7 @@ export default Service.extend({
       object: {}
     };
 
-    // Ember.Logger.debug('leaving channel', joinMsg);
+    Ember.Logger.debug('leaving channel', joinMsg);
     this.sockethub.socket.emit('message', joinMsg);
   },
 
@@ -417,66 +430,7 @@ export default Service.extend({
     };
 
     this.sockethub.socket.emit('message', topicMsg);
-  },
-
-  spaceFixtures: computed(function() {
-    // TODO: Save in remoteStorage
-    let nickname = this.get('userSettings.nickname');
-
-    if (!nickname) {
-      nickname = prompt("Choose a nickname");
-      this.set('userSettings.nickname', nickname);
-    }
-
-    return {
-      'Freenode': {
-          server : {
-            hostname: 'irc.freenode.net',
-            port: 6667,
-            secure: false,
-            username: null,
-            password: null,
-            nickname: nickname,
-            nickServ: {
-              password: null
-            }
-          },
-          channels: [
-            '#hackerbeach',
-            '#kosmos',
-            '#kosmos-dev',
-            '#kosmos-random',
-            '#sockethub'
-          ],
-      },
-      // 'Enterprise': {
-      //   server : {
-      //     hostname: 'irc.kosmos.net',
-      //     port: 6667,
-      //     secure: false,
-      //     username: null,
-      //     password: null,
-      //     nickname: 'kosmos-enterprise-dev',
-      //     nickServ: {
-      //       password: null
-      //     }
-      //   }
-      // },
-    };
-  }),
-
-  userFixtures: function() {
-    return [
-      { username: 'bkero' },
-      { username: 'derbumi' },
-      { username: 'galfert' },
-      { username: 'gregkare' },
-      { username: 'jaaan' },
-      { username: 'LSA232' },
-      { username: 'raucao' },
-      { username: 'slvrbckt' }
-    ];
-  }.property(),
+  }
 
 });
 

--- a/app/styles/_layout.scss
+++ b/app/styles/_layout.scss
@@ -92,6 +92,11 @@ div#channel {
   }
 }
 
+section#settings {
+  @include flex(1);
+  overflow: auto;
+}
+
 .app-container.global-menu-open {
   #global {
     transform: none;

--- a/app/templates/settings.hbs
+++ b/app/templates/settings.hbs
@@ -1,17 +1,32 @@
-<section id="channel-content">
-<ul>
-  <li>
-    {{input value=ircSettings.nickname placeholder="nickname"}}
-  </li>
-  <li>
-    {{input value=ircSettings.server placeholder="irc.servername.org"}}
-  </li>
-  <li>
-    {{input value=ircSettings.channel placeholder="#channel"}}
-  </li>
-  <li>
-    <button {{action "save"}}>Save</button>
-  </li>
-</ul>
-</section>
+<section id="settings">
+  <div class="content">
 
+    <h2>Spaces</h2>
+
+    {{log spaces}}
+    {{#each model.spaces as |space|}}
+      <h3>{{space.name}}</h3>
+      <button {{action "removeSpace" space}}>delete</button>
+      <hr>
+    {{/each}}
+
+    <h3>Add new space</h3>
+    <p>
+      {{input value=newSpace.name required placeholder="Freenode"}}
+    </p>
+    <p>
+      {{input value=newSpace.server.hostname required placeholder="irc.servername.org"}}
+    </p>
+    <p>
+      {{input value=newSpace.server.port required placeholder="6667"}}
+    </p>
+    <p>
+      {{input value=newSpace.server.nickname required placeholder="nickname"}}
+    </p>
+    <p>
+      <button {{action "addSpace"}}>Save</button>
+    </p>
+
+
+  </div>
+</section>

--- a/app/templates/settings.hbs
+++ b/app/templates/settings.hbs
@@ -3,7 +3,6 @@
 
     <h2>Spaces</h2>
 
-    {{log spaces}}
     {{#each model.spaces as |space|}}
       <h3>{{space.name}}</h3>
       <button {{action "removeSpace" space}}>delete</button>
@@ -11,22 +10,23 @@
     {{/each}}
 
     <h3>Add new space</h3>
-    <p>
-      {{input value=newSpace.name required placeholder="Freenode"}}
-    </p>
-    <p>
-      {{input value=newSpace.server.hostname required placeholder="irc.servername.org"}}
-    </p>
-    <p>
-      {{input value=newSpace.server.port required placeholder="6667"}}
-    </p>
-    <p>
-      {{input value=newSpace.server.nickname required placeholder="nickname"}}
-    </p>
-    <p>
-      <button {{action "addSpace"}}>Save</button>
-    </p>
-
+    <form {{action "addSpace"}} name="add-space">
+      <p>
+        {{input value=newSpace.name required="required" placeholder="Freenode"}}
+      </p>
+      <p>
+        {{input value=newSpace.server.hostname required="required" placeholder="irc.servername.org"}}
+      </p>
+      <p>
+        {{input value=newSpace.server.port required="required" placeholder="6667"}}
+      </p>
+      <p>
+        {{input value=newSpace.server.nickname required="required" placeholder="nickname"}}
+      </p>
+      <p>
+        <input type="submit" value="Save">
+      </p>
+    </form>
 
   </div>
 </section>

--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,6 @@
     "bourbon": "^4.2.7",
     "ember": "~2.8.0",
     "ember-cli-shims": "0.1.1",
-    "remotestorage": "~0.13.0",
     "linkifyjs": "~2.1.3",
     "hammer.js": "2.0.6",
     "hammer-time": "1.0.0"

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "ember-resolver": "^2.0.3",
     "ember-route-action-helper": "2.0.2",
     "loader.js": "^4.0.1",
-    "remotestoragejs": "remotestorage/remotestorage.js#feature/949-noglobal"
+    "remotestoragejs": "remotestorage/remotestorage.js#feature/949-noglobal",
+    "remotestorage-module-kosmos": "/home/basti/src/remotestorage/modules/remotestorage-module-kosmos"
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.2",
     "ember-ajax": "^2.0.1",
+    "ember-browserify": "^1.1.13",
     "ember-cli": "2.8.0",
     "ember-cli-app-version": "^1.0.0",
     "ember-cli-babel": "^5.1.6",
@@ -45,7 +46,6 @@
     "ember-cli-moment-shim": "3.0.1",
     "ember-cli-qunit": "^2.1.0",
     "ember-cli-release": "^0.2.9",
-    "ember-cli-remotestorage": "remotestorage/ember-cli-remotestorage",
     "ember-cli-sass": "^5.5.2",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-test-loader": "^1.1.0",
@@ -59,6 +59,7 @@
     "ember-moment": "7.3.0",
     "ember-resolver": "^2.0.3",
     "ember-route-action-helper": "2.0.2",
-    "loader.js": "^4.0.1"
+    "loader.js": "^4.0.1",
+    "remotestoragejs": "remotestorage/remotestorage.js#feature/949-noglobal"
   }
 }

--- a/tests/unit/initializers/remotestorage-test.js
+++ b/tests/unit/initializers/remotestorage-test.js
@@ -1,0 +1,24 @@
+import Ember from 'ember';
+import { initialize } from 'hyperchannel/initializers/remotestorage';
+import { module, test } from 'qunit';
+import destroyApp from '../../helpers/destroy-app';
+
+module('Unit | Initializer | remotestorage', {
+  beforeEach() {
+    Ember.run(() => {
+      this.application = Ember.Application.create();
+      this.application.deferReadiness();
+    });
+  },
+  afterEach() {
+    destroyApp(this.application);
+  }
+});
+
+// Replace this with your real tests.
+test('it works', function(assert) {
+  initialize(this.application);
+
+  // you would normally confirm the results of the initializer here
+  assert.ok(true);
+});

--- a/tests/unit/services/remotestorage-test.js
+++ b/tests/unit/services/remotestorage-test.js
@@ -1,0 +1,12 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('service:remotestorage', 'Unit | Service | remotestorage', {
+  // Specify the other units that are required for this test.
+  // needs: ['service:foo']
+});
+
+// Replace this with your real tests.
+test('it exists', function(assert) {
+  let service = this.subject();
+  assert.ok(service);
+});


### PR DESCRIPTION
This adds the current beta version directly from the RS repo's noglobal branch and imports it via ember-browserify as ES6 module.

It also adds the RS instance to `window` so it's available for debugging and playing around in the browser console.