### PR TITLE
Fix swiping in Chrome

### DIFF
--- a/app/styles/_layout.scss
+++ b/app/styles/_layout.scss
@@ -11,6 +11,7 @@
   .main {
     @include flex(1);
     overflow: auto;
+    -webkit-overflow-scrolling: touch;
   }
   footer {
     @include flex(0 0 $headerHeight);
@@ -25,6 +26,7 @@
   bottom: 0;
   right: 0;
   overflow: hidden;
+  -webkit-overflow-scrolling: none;
   @include display(flex);
   @include align-items(stretch);
   @include flex-direction(row);

--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
     "ember-cli-shims": "0.1.1",
     "remotestorage": "~0.13.0",
     "linkifyjs": "~2.1.3",
-    "hammer.js": "2.0.6",
+    "hammer.js": "https://github.com/67P/hammer.js.git#5e94d08435b3dda3",
     "hammer-time": "1.0.0"
   }
 }


### PR DESCRIPTION
Connected to #63

I created an intermittent patched version of hammer.js that fixed our swiping problem in mobile Chrome. I got that fix from the original issue discussion. Apparently it breaks pan support in desktop Chrome, but since we are not using that I think that's ok for now.

I'll keep an eye on the original issue to see when they found a proper fix for it.

While at it I also enabled momentum scrolling for mobile Safari. Feels much nicer.