### PR TITLE
Don't bounce when scrolling to top or bottom on mobile Safari

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,7 @@
     "remotestorage": "~0.13.0",
     "linkifyjs": "~2.1.3",
     "hammer.js": "2.0.6",
-    "hammer-time": "1.0.0"
+    "hammer-time": "1.0.0",
+    "inobounce": "^0.1.4"
   }
 }

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -41,6 +41,7 @@ module.exports = function(defaults) {
 
   app.import('bower_components/linkifyjs/linkify.min.js');
   app.import('bower_components/linkifyjs/linkify-string.min.js');
+  app.import('bower_components/inobounce/inobounce.js');
 
   return app.toTree();
 };


### PR DESCRIPTION
This keeps the top menu at it's place when scrolling all the way up to the top.