### PR TITLE
Add ServiceWorker for offline assets

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -3,6 +3,7 @@
     "document",
     "window",
     "-Promise",
+    "Promise",
     "linkifyStr"
   ],
   "browser": true,

--- a/config/environment.js
+++ b/config/environment.js
@@ -13,7 +13,7 @@ module.exports = function(environment) {
       }
     },
 
-    sockethubURL: 'localhost:10550',
+    sockethubURL: 'http://localhost:10550',
 
     APP: {
       // Here you can pass flags/options to your application instance
@@ -46,6 +46,34 @@ module.exports = function(environment) {
     // TODO move to user-editable config
     ENV.sockethubURL = 'https://sockethub.kosmos.org:10550';
   }
+
+  //
+  // Service Worker
+  //
+  ENV.serviceWorker = {
+    enabled: true,
+    debug: true,
+    // precacheURLs: [
+    // ],
+    networkFirstURLs: [
+      /activity\-streams\.js/,
+      /socket\.io\.js/,
+      /sockethub\-client\.js/
+    ],
+    excludePaths: [/test.*/, 'robots.txt', 'crossdomain.xml'],
+    // fallback: [
+    //   '/online.html /offline.html'
+    // ],
+    includeRegistration: true,
+    // serviceWorkerFile: "service-worker.js",
+    // skipWaiting: true,
+    // swIncludeFiles: [
+    //   'bower_components/pouchdb/dist/pouchdb.js'
+    // ],
+    swEnvironment: {
+      sockethubURL: ENV.sockethubURL
+    }
+  };
 
   return ENV;
 };

--- a/config/environment.js
+++ b/config/environment.js
@@ -23,7 +23,37 @@ module.exports = function(environment) {
     publicLogsUrl: 'https://storage.5apps.com/kosmos/public/chat-messages'
   };
 
+  //
+  // Service Worker
+  //
+  ENV.serviceWorker = {
+    enabled: false,
+    includeRegistration: false,
+    debug: false,
+    // precacheURLs: [
+    // ],
+    networkFirstURLs: [
+      /activity\-streams\.js/,
+      /socket\.io\.js/,
+      /sockethub\-client\.js/
+    ],
+    excludePaths: [/test.*/, 'robots.txt', 'crossdomain.xml'],
+    // fallback: [
+    //   '/online.html /offline.html'
+    // ],
+    // serviceWorkerFile: "service-worker.js",
+    // skipWaiting: true,
+    // swIncludeFiles: [
+    //   'bower_components/pouchdb/dist/pouchdb.js'
+    // ],
+    // swEnvironment: {
+    // }
+  };
+
   if (environment === 'development') {
+    // ENV.serviceWorker.enabled = true;
+    // ENV.serviceWorker.includeRegistration = true;
+    // ENV.serviceWorker.debug = true;
     // ENV.APP.LOG_RESOLVER = true;
     // ENV.APP.LOG_ACTIVE_GENERATION = true;
     // ENV.APP.LOG_TRANSITIONS = true;
@@ -43,37 +73,11 @@ module.exports = function(environment) {
   }
 
   if (environment === 'production') {
-    // TODO move to user-editable config
     ENV.sockethubURL = 'https://sockethub.kosmos.org:10550';
-  }
 
-  //
-  // Service Worker
-  //
-  ENV.serviceWorker = {
-    enabled: true,
-    debug: true,
-    // precacheURLs: [
-    // ],
-    networkFirstURLs: [
-      /activity\-streams\.js/,
-      /socket\.io\.js/,
-      /sockethub\-client\.js/
-    ],
-    excludePaths: [/test.*/, 'robots.txt', 'crossdomain.xml'],
-    // fallback: [
-    //   '/online.html /offline.html'
-    // ],
-    includeRegistration: true,
-    // serviceWorkerFile: "service-worker.js",
-    // skipWaiting: true,
-    // swIncludeFiles: [
-    //   'bower_components/pouchdb/dist/pouchdb.js'
-    // ],
-    swEnvironment: {
-      sockethubURL: ENV.sockethubURL
-    }
-  };
+    ENV.serviceWorker.enabled = true;
+    ENV.serviceWorker.includeRegistration = true;
+  }
 
   return ENV;
 };

--- a/config/environment.js
+++ b/config/environment.js
@@ -29,7 +29,7 @@ module.exports = function(environment) {
   ENV.serviceWorker = {
     enabled: false,
     includeRegistration: false,
-    debug: false,
+    debug: true,
     // precacheURLs: [
     // ],
     networkFirstURLs: [

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "license": "MPL",
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.2",
+    "broccoli-serviceworker": "0.1.4",
     "ember-ajax": "^2.0.1",
     "ember-cli": "2.8.0",
     "ember-cli-app-version": "^1.0.0",

--- a/vendor/sh-assets-local.html
+++ b/vendor/sh-assets-local.html
@@ -1,3 +1,3 @@
 <script src="http://localhost:10550/activity-streams.js"></script>
-<script src="http://localhost:10550/sockethub/socket.io.js"></script>
+<script src="http://localhost:10550/socket.io.js"></script>
 <script src="http://localhost:10550/sockethub-client.js"></script>

--- a/vendor/sh-assets-remote.html
+++ b/vendor/sh-assets-remote.html
@@ -1,3 +1,3 @@
 <script src="https://sockethub.kosmos.org:10550/activity-streams.js"></script>
-<script src="https://sockethub.kosmos.org:10550/sockethub/socket.io.js"></script>
+<script src="https://sockethub.kosmos.org:10550/socket.io.js"></script>
 <script src="https://sockethub.kosmos.org:10550/sockethub-client.js"></script>


### PR DESCRIPTION
This adds `broccoli-serviceworker`, which automatically generates a `ServiceWorker` file and registration for the Ember app assets (cache-first) and the Sockethub assets (network-first). Configuration is in `config/environment.js`.

We'll need our own SW code for Push notifications and more sophisticated cash handling (e.g. for Sockethub assets), of course, so this is meant mostly for loading time improvements in production for now.

<del>Caveat: This branch only works with https://github.com/sockethub/sockethub/pull/204 because the current Sockethub master doesn't add CORS headers to the static asset responses.</del> PR has been merged. So latest `master` should work.