### PR TITLE
Don't try to load archive when joining unlogged channel

### DIFF
--- a/app/services/smt.js
+++ b/app/services/smt.js
@@ -335,7 +335,9 @@ export default Service.extend({
     this.joinChannel(space, channel, "room");
     space.get('channels').pushObject(channel);
 
-    this.loadLastMessages(space, channel, moment(), 2).catch(() => {});
+    if (channel.get('isLogged')) {
+      this.loadLastMessages(space, channel, moment(), 2).catch(() => {});
+    }
 
     return channel;
   },


### PR DESCRIPTION
Completely missed when implementing #83 that, now that we have a list of logged channels, we don't need to try to load any archive when joining an unlogged channel :)

