### PR TITLE
Fix persisting of joined channels in remoteStorage

### DIFF
--- a/app/components/channel-nav/template.hbs
+++ b/app/components/channel-nav/template.hbs
@@ -12,7 +12,7 @@
         </li>
       {{/each}}
       <li>
-        <a {{action (action joinChannel space.id)}} class="join-channel">+</a>
+        <a {{action (action joinChannel space)}} class="join-channel">+</a>
       </li>
     </ul>
   </li>

--- a/app/controllers/space/base_channel.js
+++ b/app/controllers/space/base_channel.js
@@ -52,6 +52,7 @@ export default Ember.Controller.extend({
     joinCommand: function(args) {
       let space = this.get('space.model');
       let channel = this.get('smt').createChannel(space, args[0]);
+      this.get('storage').saveSpace(space);
       this.transitionToRoute('space.channel', space, channel);
     },
 

--- a/app/controllers/space/base_channel.js
+++ b/app/controllers/space/base_channel.js
@@ -6,7 +6,6 @@ export default Ember.Controller.extend({
   newMessage: null,
   space: Ember.inject.controller(),
   smt: Ember.inject.service(),
-  storage: Ember.inject.service('remotestorage'),
 
   actions: {
     sendMessage: function(newMessage) {
@@ -53,8 +52,6 @@ export default Ember.Controller.extend({
     joinCommand: function(args) {
       let space = this.get('space.model');
       let channel = this.get('smt').createChannel(space, args[0]);
-      space.get('channelList').pushObject(channel.get('name'));
-      this.get('storage').saveSpace(space);
       this.transitionToRoute('space.channel', space, channel);
     },
 
@@ -62,8 +59,6 @@ export default Ember.Controller.extend({
       let space = this.get('space.model');
       let channelName = this.get('model.name');
       this.get('smt').removeChannel(space, channelName);
-      space.get('channelList').removeObject(channelName);
-      this.get('storage').saveSpace(space);
       let lastChannel = space.get('channels.lastObject');
       this.transitionToRoute('space.channel', space, lastChannel);
     },

--- a/app/controllers/space/base_channel.js
+++ b/app/controllers/space/base_channel.js
@@ -6,6 +6,7 @@ export default Ember.Controller.extend({
   newMessage: null,
   space: Ember.inject.controller(),
   smt: Ember.inject.service(),
+  storage: Ember.inject.service('remotestorage'),
 
   actions: {
     sendMessage: function(newMessage) {

--- a/app/models/space.js
+++ b/app/models/space.js
@@ -20,8 +20,15 @@ export default Ember.Object.extend({
     }
   },
   channels   : null, // Channel instances
-  channelList: null, // Bookmarked channel names
-  users      : null,
+
+  init() {
+    this._super(...arguments);
+    this.set('channels', []);
+  },
+
+  channelNames: computed('channels.@each.name', function() {
+    return this.get('channels').mapBy('name');
+  }),
 
   loggedChannels: computed('name', 'protocol', function() {
     if (this.get('name') === 'Freenode' && this.get('protocol') === 'IRC') {
@@ -58,7 +65,7 @@ export default Ember.Object.extend({
         secure: this.get('server.secure'),
         nickname: this.get('server.nickname'),
       },
-      channels: this.get('channelList') || []
+      channels: this.get('channelNames') || []
     };
   },
 

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -4,12 +4,14 @@ const {
   Route,
   inject: {
     service
-  }
+  },
+  isEmpty
 } = Ember;
 
 export default Route.extend({
   logger: service(),
   smt: service(),
+  storage: service('remotestorage'),
 
   beforeModel() {
     this._super(...arguments);
@@ -44,10 +46,19 @@ export default Route.extend({
       }
     },
 
-    openNewChannel(spaceId) {
+    openNewChannel(space) {
       let channelName = window.prompt('Join channel');
-      channelName = channelName.replace(/^#/, '');
-      this.transitionTo('space.channel', spaceId, channelName);
+
+      if (isEmpty(channelName)) {
+        return;
+      }
+
+      if (!channelName.match(/^#/)) {
+        channelName = `#${channelName}`;
+      }
+      let channel = this.get('smt').createChannel(space, channelName);
+      this.get('storage').saveSpace(space);
+      this.transitionTo('space.channel', space, channel);
     }
 
   }

--- a/app/services/remotestorage.js
+++ b/app/services/remotestorage.js
@@ -44,10 +44,10 @@ export default Ember.Service.extend({
       .then(() => {
         Ember.Logger.debug('[remotestorage]', 'created/stored default space');
 
-        params.channelList = params.channels;
+        let channels = params.channels;
         delete params.channels;
 
-        return Space.create(params);
+        return { space: Space.create(params), channels: channels };
       });
   },
 

--- a/app/services/smt.js
+++ b/app/services/smt.js
@@ -330,8 +330,6 @@ export default Service.extend({
     this.joinChannel(space, channel, "room");
     space.get('channels').pushObject(channel);
 
-    this.get('storage').saveSpace(space);
-
     if (channel.get('isLogged')) {
       this.loadLastMessages(space, channel, moment(), 2).catch(() => {});
     }

--- a/tests/unit/models/space-test.js
+++ b/tests/unit/models/space-test.js
@@ -32,3 +32,15 @@ test('#loggedChannels returns empty list when space is not Freenode', function(a
 
   assert.equal(space.get('loggedChannels').length, 0);
 });
+
+test('#channelNames returns names of the channels', function(assert) {
+  let space = this.subject();
+
+  space.set('channels', [
+    Channel.create({ name: '#kosmos' }),
+    Channel.create({ name: '#kosmos-dev' }),
+    Channel.create({ name: '#remotestorage' }),
+  ]);
+
+  assert.deepEqual(space.get('channelNames'), ['#kosmos', '#kosmos-dev', '#remotestorage']);
+});


### PR DESCRIPTION
The channels were only persisted when joining via the `/join` command, but not when using the + from the menu. I moved the persisting to the method that both the features use.

Also, when leaving channels, the two properties `channels` and `channelList` of the `Space` model diverted. This prevented the channels from being removed from remoteStorage. I changed the list of channel names to be a computed property based on the actual list of channels instead.

