### PR TITLE
Add noopener and noreferrer to links with target _blank

### DIFF
--- a/app/components/message-chat/component.js
+++ b/app/components/message-chat/component.js
@@ -28,14 +28,14 @@ export default Ember.Component.extend({
 
     // Images
     if (content.match(/^(http)s?:\/\/.*(gif|png|jpg|jpeg)$/i)) {
-      out = `<br><a href="${content}" target="_blank" rel="nofollow">` +
+      out = `<br><a href="${content}" target="_blank" rel="nofollow noopener noreferrer">` +
             `<img src="${content}" class="from-image-url" alt="${content}">` +
             `</a>`;
     }
     // Other links
     else {
       out = linkifyStr(content, {
-        linkAttributes: { rel: 'nofollow' },
+        linkAttributes: { rel: 'nofollow noopener noreferrer' },
         validate: {
           url: function (value) {
             return /^(http)s?:\/\//.test(value);

--- a/app/components/message-chat/component.js
+++ b/app/components/message-chat/component.js
@@ -28,14 +28,14 @@ export default Ember.Component.extend({
 
     // Images
     if (content.match(/^(http)s?:\/\/.*(gif|png|jpg|jpeg)$/i)) {
-      out = `<br><a href="${content}" target="_blank" rel="nofollow noopener noreferrer">` +
+      out = `<br><a href="${content}" target="_blank" rel="nofollow noopener">` +
             `<img src="${content}" class="from-image-url" alt="${content}">` +
             `</a>`;
     }
     // Other links
     else {
       out = linkifyStr(content, {
-        linkAttributes: { rel: 'nofollow noopener noreferrer' },
+        linkAttributes: { rel: 'nofollow noopener' },
         validate: {
           url: function (value) {
             return /^(http)s?:\/\//.test(value);

--- a/tests/unit/components/message-chat-test.js
+++ b/tests/unit/components/message-chat-test.js
@@ -9,7 +9,7 @@ test('#formattedContent turns full URLs into links', function(assert) {
     message: { content: 'visit https://kosmos.org for more info' }
   });
 
-  assert.equal(component.get('formattedContent').toString(), 'visit <a href="https://kosmos.org" class="linkified" target="_blank" rel="nofollow">https://kosmos.org</a> for more info');
+  assert.equal(component.get('formattedContent').toString(), 'visit <a href="https://kosmos.org" class="linkified" target="_blank" rel="nofollow noopener noreferrer">https://kosmos.org</a> for more info');
 });
 
 test('#formattedContent does not turn domain names into links', function(assert) {
@@ -41,5 +41,5 @@ test('#formattedContent renders images from image URLs', function(assert) {
     message: { content: 'https://storage.5apps.com/basti/public/shares/160527-1119-magic.gif' }
   });
 
-  assert.equal(component.get('formattedContent').toString(), '<br><a href="https://storage.5apps.com/basti/public/shares/160527-1119-magic.gif" target="_blank" rel="nofollow"><img src="https://storage.5apps.com/basti/public/shares/160527-1119-magic.gif" class="from-image-url" alt="https://storage.5apps.com/basti/public/shares/160527-1119-magic.gif"></a>');
+  assert.equal(component.get('formattedContent').toString(), '<br><a href="https://storage.5apps.com/basti/public/shares/160527-1119-magic.gif" target="_blank" rel="nofollow noopener noreferrer"><img src="https://storage.5apps.com/basti/public/shares/160527-1119-magic.gif" class="from-image-url" alt="https://storage.5apps.com/basti/public/shares/160527-1119-magic.gif"></a>');
 });

--- a/tests/unit/components/message-chat-test.js
+++ b/tests/unit/components/message-chat-test.js
@@ -9,7 +9,7 @@ test('#formattedContent turns full URLs into links', function(assert) {
     message: { content: 'visit https://kosmos.org for more info' }
   });
 
-  assert.equal(component.get('formattedContent').toString(), 'visit <a href="https://kosmos.org" class="linkified" target="_blank" rel="nofollow noopener noreferrer">https://kosmos.org</a> for more info');
+  assert.equal(component.get('formattedContent').toString(), 'visit <a href="https://kosmos.org" class="linkified" target="_blank" rel="nofollow noopener">https://kosmos.org</a> for more info');
 });
 
 test('#formattedContent does not turn domain names into links', function(assert) {
@@ -41,5 +41,5 @@ test('#formattedContent renders images from image URLs', function(assert) {
     message: { content: 'https://storage.5apps.com/basti/public/shares/160527-1119-magic.gif' }
   });
 
-  assert.equal(component.get('formattedContent').toString(), '<br><a href="https://storage.5apps.com/basti/public/shares/160527-1119-magic.gif" target="_blank" rel="nofollow noopener noreferrer"><img src="https://storage.5apps.com/basti/public/shares/160527-1119-magic.gif" class="from-image-url" alt="https://storage.5apps.com/basti/public/shares/160527-1119-magic.gif"></a>');
+  assert.equal(component.get('formattedContent').toString(), '<br><a href="https://storage.5apps.com/basti/public/shares/160527-1119-magic.gif" target="_blank" rel="nofollow noopener"><img src="https://storage.5apps.com/basti/public/shares/160527-1119-magic.gif" class="from-image-url" alt="https://storage.5apps.com/basti/public/shares/160527-1119-magic.gif"></a>');
 });


### PR DESCRIPTION
I saw a talk about Ember security yesterday. One of the suggestions was to always use `noopener` and `noreferrer` as values for the `rel` attribute of links with target `_blank` to prevent a possible XSS vulnerability.