### PR TITLE
Fix channel creation from updateChannelTopic method

### DIFF
--- a/app/services/coms.js
+++ b/app/services/coms.js
@@ -223,7 +223,8 @@ export default Service.extend({
       let channel = space.get('channels').findBy('sockethubChannelId', message.target['@id']);
 
       if (isEmpty(channel)) {
-        channel = this.createChannel(space, message.target['@id']);
+        Ember.Logger.warn('No channel for update topic message found. Creating it.', message);
+        channel = this.createChannel(space, message.target['displayName']);
       }
 
       let currentTopic = channel.get('topic');

--- a/app/services/coms.js
+++ b/app/services/coms.js
@@ -202,7 +202,7 @@ export default Service.extend({
     var space = this.get('spaces').findBy('server.hostname', hostname);
 
     if (!isEmpty(space)) {
-      var channel = space.get('channels').findBy('sockethubChannelId', message.target['@id']);
+      var channel = space.get('channels').findBy('sockethubChannelId', message.actor['@id']);
       if (!isEmpty(channel)) {
         return channel;
       }
@@ -401,7 +401,7 @@ export default Service.extend({
 
     switch(message['@type']) {
       case 'join':
-        var space = this.get('spaces').findBy('sockethubPersonId', message.actor);
+        var space = this.get('spaces').findBy('sockethubPersonId', message.actor['@id']);
         if (!isEmpty(space)) {
           this.get(message.context).handleJoinCompleted(space, message);
         }

--- a/app/services/sockethub-irc.js
+++ b/app/services/sockethub-irc.js
@@ -87,7 +87,7 @@ export default Ember.Service.extend({
   },
 
   handleJoinCompleted(space, message) {
-    var channel = space.get('channels').findBy('sockethubChannelId', message.target);
+    var channel = space.get('channels').findBy('sockethubChannelId', message.target['@id']);
     if (!isEmpty(channel)) {
       channel.set('connected', true);
       this.observeChannel(space, channel);


### PR DESCRIPTION
Closes #84

When getting a channel update message from Sockethub for a channel that didn't exist in Hyperchannel yet (happens when using the app in two tabs or two different browsers), it was creating the channel with the full id instead of just the name.