### PR TITLE
Use postcss and autoprefixer, remove old bourbon mixins

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -4,7 +4,8 @@
     "window",
     "-Promise",
     "Promise",
-    "linkifyStr"
+    "linkifyStr",
+    "process"
   ],
   "browser": true,
   "boss": true,

--- a/app/styles/_layout.scss
+++ b/app/styles/_layout.scss
@@ -1,20 +1,20 @@
 @mixin app-column() {
-  @include display(flex);
-  @include align-items(stretch);
-  @include flex-direction(column);
-  @include justify-content(flex-start);
+  display: flex;
+  align-items: stretch;
+  flex-direction: column;
+  justify-content: flex-start;
 
   header {
-    @include flex(0 0 $headerHeight);
+    flex: 0 0 $headerHeight;
     position: relative;
   }
   .main {
-    @include flex(1);
+    flex: 1;
     overflow: auto;
     -webkit-overflow-scrolling: touch;
   }
   footer {
-    @include flex(0 0 $headerHeight);
+    flex: 0 0 $headerHeight;
     position: relative;
   }
 }
@@ -27,10 +27,10 @@
   right: 0;
   overflow: hidden;
   -webkit-overflow-scrolling: none;
-  @include display(flex);
-  @include align-items(stretch);
-  @include flex-direction(row);
-  @include justify-content(flex-start);
+  display: flex;
+  align-items: stretch;
+  flex-direction: row;
+  justify-content: flex-start;
 }
 
 #global {
@@ -48,7 +48,7 @@
 
 @media screen and (min-width: 900px) {
   #global {
-    @include flex(0 0 $sidebarWidth);
+    flex: 0 0 $sidebarWidth;
     @include app-column;
   }
 }
@@ -73,29 +73,29 @@
 }
 
 div#channel {
-  @include flex(1);
+  flex: 1;
 
-  @include display(flex);
-  @include align-items(stretch);
-  @include flex-direction(row);
-  @include justify-content(flex-start);
+  display: flex;
+  align-items: stretch;
+  flex-direction: row;
+  justify-content: flex-start;
 
   transform: none;
   transition: transform 0.4s;
 
   main {
-    @include flex(1);
+    flex: 1;
     @include app-column;
   }
 
   aside {
-    @include flex(0 0 $sidebarWidth);
+    flex: 0 0 $sidebarWidth;
     @include app-column;
   }
 }
 
 section#settings {
-  @include flex(1);
+  flex: 1;
   overflow: auto;
 }
 

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -1,6 +1,6 @@
-$output-bourbon-deprecation-warnings: false;
 @import "bourbon";
 
+$modular-scale-ratio: $golden;
 $headerHeight: 42px;
 $sidebarWidth: 168px;
 
@@ -80,10 +80,10 @@ header {
       }
     }
     li {
-      @include transition(opacity 0.2s linear);
+      transition: opacity 0.2s linear;
       &.disconnected {
         opacity: 0.5;
-        @include transition(opacity 0.2s linear);
+        transition: opacity 0.2s linear;
       }
     }
     > ul {

--- a/app/styles/components/date-headline.scss
+++ b/app/styles/components/date-headline.scss
@@ -1,7 +1,7 @@
 .date-headline {
 
   overflow: hidden;
-  @include background-image(linear-gradient(top, rgba(255,0,0,0), rgba(255,0,0,0) 49%, #efefef 50%, #efefef 52%, rgba(255,0,0,0) 52%, rgba(255,0,0,0)));
+  background-image: linear-gradient(to bottom, rgba(255,0,0,0), rgba(255,0,0,0) 49%, #efefef 50%, #efefef 52%, rgba(255,0,0,0) 52%, rgba(255,0,0,0));
   padding-top: 1rem;
   padding-bottom: 1rem;
   text-align: center;
@@ -10,7 +10,7 @@
     display: inline-block;
     padding-left: 1.5rem;
     padding-right: 1.5rem;
-    line-height: golden-ratio(1em, 1);
+    line-height: modular-scale(1);
     background-color: #fff;
     color: #aaa;
   }

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -26,12 +26,11 @@ module.exports = function(defaults) {
       ]
     },
     postcssOptions: {
-      compile: {
+      filter: {
         enabled: false
       },
-      filter: {
+      compile: {
         enabled: true,
-        exclude: ['assets/vendor.css'],
         plugins: [
           {
             module: autoprefixer,

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -1,6 +1,7 @@
 /* eslint-env node */
 /* global require, module */
 const EmberApp = require('ember-cli/lib/broccoli/ember-app');
+var autoprefixer = require('autoprefixer');
 
 module.exports = function(defaults) {
 
@@ -23,6 +24,23 @@ module.exports = function(defaults) {
       includePaths: [
         'bower_components/bourbon/app/assets/stylesheets'
       ]
+    },
+    postcssOptions: {
+      compile: {
+        enabled: false
+      },
+      filter: {
+        enabled: true,
+        exclude: ['assets/vendor.css'],
+        plugins: [
+          {
+            module: autoprefixer,
+            options: {
+              browsers: ['last 4 versions']
+            }
+          }
+        ]
+      }
     }
   });
 

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -26,11 +26,12 @@ module.exports = function(defaults) {
       ]
     },
     postcssOptions: {
-      filter: {
+      compile: {
         enabled: false
       },
-      compile: {
+      filter: {
         enabled: true,
+        exclude: ['assets/vendor.css'],
         plugins: [
           {
             module: autoprefixer,

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "node": ">= 6.0.0"
   },
   "devDependencies": {
+    "autoprefixer": "^7.0.1",
     "bower": "^1.8.0",
     "broccoli-asset-rev": "^2.4.5",
     "broccoli-serviceworker": "0.1.4",
@@ -46,6 +47,7 @@
     "ember-cli-inject-live-reload": "^1.4.1",
     "ember-cli-inline-content": "^0.4.1",
     "ember-cli-moment-shim": "3.1.0",
+    "ember-cli-postcss": "^3.2.0",
     "ember-cli-qunit": "^4.0.0",
     "ember-cli-sass": "^6.1.3",
     "ember-cli-shims": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "ember-cli-inject-live-reload": "^1.4.1",
     "ember-cli-inline-content": "^0.4.1",
     "ember-cli-moment-shim": "3.1.0",
-    "ember-cli-postcss": "^3.2.0",
+    "ember-cli-postcss": "^3.3.0",
     "ember-cli-qunit": "^4.0.0",
     "ember-cli-sass": "^6.1.3",
     "ember-cli-shims": "^1.1.0",


### PR DESCRIPTION
This switches some of Bourbon's deprecated mixins to normal syntax, for
which prefixes are added by postcss/autoprefixer instead.

connected to #114
closes #114