### PR TITLE
Mark channels of all spaces as invisible when switching

### DIFF
--- a/app/routes/space/base_channel.js
+++ b/app/routes/space/base_channel.js
@@ -52,8 +52,12 @@ export default Route.extend({
       this.set('userSettings.currentSpace', space.get('id'));
       this.set('userSettings.currentChannel', channel.get('slug'));
 
+      // Mark all other channels as inactive/invisible
+      this.get('coms.spaces').forEach((space) => {
+        space.get('channels').setEach('visible', false);
+      });
+
       // Mark channel as active/visible
-      space.get('channels').setEach('visible', false);
       channel.set('visible', true);
 
       // Mark unread messages as read


### PR DESCRIPTION
Fixes #122

When there are multiple spaces, switching channels still kept the channel of the second space marked as visible, preventing the highlight when new messages arrived for that channel.