### PR TITLE
Update SW deps, use SW in dev

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -60,6 +60,9 @@ module.exports = function(environment) {
     // ENV.APP.LOG_TRANSITIONS = true;
     // ENV.APP.LOG_TRANSITIONS_INTERNAL = true;
     // ENV.APP.LOG_VIEW_LOOKUPS = true;
+
+    ENV.serviceWorker.enabled = true;
+    ENV.serviceWorker.includeRegistration = true;
   }
 
   if (environment === 'test') {

--- a/package-lock.json
+++ b/package-lock.json
@@ -969,6 +969,12 @@
       "integrity": "sha1-MsNpFpEM6qImdhT740QugtIhzjw=",
       "dev": true,
       "dependencies": {
+        "has-flag": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+          "dev": true
+        },
         "postcss": {
           "version": "6.0.1",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.1.tgz",
@@ -993,6 +999,12 @@
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/broccoli-caching-writer/-/broccoli-caching-writer-3.0.3.tgz",
           "integrity": "sha1-C9LJapc41qarWQ8HujXFFX19tHY=",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
           "dev": true
         },
         "postcss": {
@@ -1032,18 +1044,39 @@
       }
     },
     "broccoli-serviceworker": {
-      "version": "https://registry.npmjs.org/broccoli-serviceworker/-/broccoli-serviceworker-0.1.4.tgz",
-      "integrity": "sha1-uv8fcahnC5AUrqa/fUyELeP+m3I=",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/broccoli-serviceworker/-/broccoli-serviceworker-0.1.6.tgz",
+      "integrity": "sha1-ES/4pNEs4C37m4G/oh33gl80Yyw=",
       "dev": true,
       "dependencies": {
         "broccoli-funnel": {
-          "version": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-1.0.9.tgz",
+          "version": "1.0.9",
+          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-1.0.9.tgz",
           "integrity": "sha1-GyZzvmbdiodxIU4/OutzJQEuRYA=",
           "dev": true
         },
         "broccoli-merge-trees": {
-          "version": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-1.1.5.tgz",
+          "version": "1.1.5",
+          "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-1.1.5.tgz",
           "integrity": "sha1-WDGrItY6R962U/gvTZqbtCmRuYw=",
+          "dev": true
+        },
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "path-to-regexp": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+          "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+          "dev": true
+        },
+        "sw-toolbox": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/sw-toolbox/-/sw-toolbox-3.4.0.tgz",
+          "integrity": "sha1-oW7+z0p57TIZHPGSNSXy7om8dtw=",
           "dev": true
         }
       }
@@ -1182,9 +1215,9 @@
       "dev": true,
       "dependencies": {
         "caniuse-lite": {
-          "version": "1.0.30000692",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000692.tgz",
-          "integrity": "sha1-NGAP1xUjUthaR/RmKjtRsC2LZG8=",
+          "version": "1.0.30000696",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000696.tgz",
+          "integrity": "sha1-MPJpXSoBoN/XeaJquD9NE0s9pcw=",
           "dev": true
         }
       }
@@ -5584,9 +5617,9 @@
       "dev": true
     },
     "has-flag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-      "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
       "dev": true
     },
     "has-unicode": {
@@ -7101,15 +7134,15 @@
       "dev": true
     },
     "postcss": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.2.tgz",
-      "integrity": "sha1-XE/qWJ8Kw7AMqnWxy8OihBlbfl0=",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.3.tgz",
+      "integrity": "sha1-t/Vls9lW+7hWXKfB4jnQUG5CfYs=",
       "dev": true,
       "dependencies": {
         "supports-color": {
-          "version": "3.2.3",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.0.0.tgz",
+          "integrity": "sha1-M6fGgKpRLJ0D75KcrLuXTSA9J5A=",
           "dev": true
         }
       }
@@ -8128,23 +8161,6 @@
       "version": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
       "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
       "dev": true
-    },
-    "sw-toolbox": {
-      "version": "https://registry.npmjs.org/sw-toolbox/-/sw-toolbox-3.6.0.tgz",
-      "integrity": "sha1-Jt8dHHA0hljk3qKIQxkUm3sxg7U=",
-      "dev": true,
-      "dependencies": {
-        "isarray": {
-          "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "dev": true
-        },
-        "path-to-regexp": {
-          "version": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
-          "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
-          "dev": true
-        }
-      }
     },
     "symlink-or-copy": {
       "version": "https://registry.npmjs.org/symlink-or-copy/-/symlink-or-copy-1.1.8.tgz",

--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
   "devDependencies": {
     "autoprefixer": "^7.0.1",
     "bower": "^1.8.0",
-    "broccoli-asset-rev": "^2.4.5",
-    "broccoli-serviceworker": "0.1.4",
+    "broccoli-asset-rev": "^2.5.0",
+    "broccoli-serviceworker": "0.1.6",
     "ember-ajax": "^3.0.0",
     "ember-browserify": "^1.1.13",
     "ember-cli": "2.13.1",


### PR DESCRIPTION
This updates the ServiceWorker-related deps and enables SW in development. It actually works just fine in FF in development, but not with the hosted version. I'll investigate what's wrong on the 5apps side of things, but it doesn't look like a bug in the plugin. Even more so, because nobody else reported it on the plugin source repo.

refs #80