### PR TITLE
Handle channel user list for XMPP

### DIFF
--- a/app/services/coms.js
+++ b/app/services/coms.js
@@ -161,7 +161,16 @@ export default Service.extend({
   },
 
   updateChannelUserList(message) {
-    const channel = this.getChannelById(message.actor['@id']);
+    let channel;
+    switch(message.context) {
+      case 'irc':
+        channel = this.getChannelById(message.actor['@id']);
+        break;
+      case 'xmpp':
+        channel = this.getChannel(message.target['@id'], message.actor['@id']);
+        break;
+    }
+
     if (channel) {
       channel.set('connected', true);
       if (Array.isArray(message.object.members)) {

--- a/app/services/sockethub-xmpp.js
+++ b/app/services/sockethub-xmpp.js
@@ -94,8 +94,8 @@ export default Ember.Service.extend({
   handleJoinCompleted(space, message) {
     const channelId = message.target['@id'].split('/')[0];
     const channel = space.get('channels').findBy('sockethubChannelId', channelId);
-    if (!isEmpty(channel)) {
-      channel.set('connected', true);
+    if (channel) {
+      this.observeChannel(space, channel);
     } else {
       Logger.warn('Could not find channel for join message', message);
     }
@@ -188,6 +188,26 @@ export default Ember.Service.extend({
     if (channelMessage.get('nickname') !== space.get('userNickname')) {
       channel.addMessage(channelMessage);
     }
+  },
+
+  /**
+   * Ask for a channel's attendance list (users currently joined)
+   *
+   * @param {Space} space
+   * @param {Channel} channel
+   * @public
+   */
+  observeChannel(space, channel) {
+    let observeMsg = buildActivityObject(space, {
+      '@type': 'observe',
+      target: channel.get('sockethubChannelId'),
+      object: {
+        '@type': 'attendance'
+      }
+    });
+
+    this.log('xmpp', 'asking for attendance list', observeMsg);
+    this.sockethub.socket.emit('message', observeMsg);
   },
 
   /**


### PR DESCRIPTION
Closes #127 

This queries for the room attendance list when joining a new room and handles the corresponding response from Sockethub.

It needs the implementation for Sockethub XMPP platform, which I created a PR for at sockethub/sockethub-platform-xmpp#15

Right now this only seems to work properly when connected to XMPP alone, but not when also connected to IRC. I think this is related to the issue reported at sockethub/sockethub-platform-irc#22, in which @skddc already suspected it might not just be an IRC issue but a general multiple connections issue.