### PR TITLE
Fix overflow problems on mobile

### DIFF
--- a/app/styles/_layout.scss
+++ b/app/styles/_layout.scss
@@ -82,10 +82,14 @@ div#channel {
 
   transform: none;
   transition: transform 0.4s;
+  overflow: auto;
+  overflow-wrap: break-word;
 
   main {
     flex: 1;
     @include app-column;
+
+    overflow: auto;
   }
 
   aside {

--- a/app/styles/components/message-chat.scss
+++ b/app/styles/components/message-chat.scss
@@ -69,20 +69,6 @@
   a {
     text-decoration: underline;
     color: #339;
-
-    /* These are technically the same, but use both */
-    overflow-wrap: break-word;
-    word-wrap: break-word;
-    /* IE
-    -ms-word-break: break-all;
-    /* Instead use this non-standard one: */
-    word-break: break-word;
-    /* Adds a hyphen where the word breaks, if supported (No Blink) */
-    -ms-hyphens: auto;
-    -moz-hyphens: auto;
-    -webkit-hyphens: auto;
-    hyphens: auto;
-
   }
 
   img {


### PR DESCRIPTION
The PR adds `overflow: auto` to `#channel` and `main` and `overflow-wrap: break-word` to `#channel` to make it work on mobile.

As a side effect we can remove the `.chat-message a` wrap rules.