### PR TITLE
Web Push Notifications for username mentions

### DIFF
--- a/app/components/channel-container/template.hbs
+++ b/app/components/channel-container/template.hbs
@@ -21,9 +21,9 @@
         </li>
       {{else}}
         {{#if channel.isLogged}}
-          <li class="no-messages">No recent messages to display.</li>
+          <li class="no-messages discreet">No recent messages to display.</li>
         {{else}}
-          <li class="no-messages">No Kosmos logs configured for this channel. <a href="https://wiki.kosmos.org/Setting_up_channel_logs" target="_blank">Learn more</a></li>
+          <li class="no-messages discreet">No Kosmos logs configured for this channel. <a href="https://wiki.kosmos.org/Setting_up_channel_logs" target="_blank">Learn more</a></li>
         {{/if}}
       {{/each}}
     </ul>

--- a/app/components/web-push-subscription/component.js
+++ b/app/components/web-push-subscription/component.js
@@ -1,0 +1,71 @@
+import Component from '@ember/component';
+import { computed } from '@ember/object';
+import urlBase64ToUint8Array from 'hyperchannel/utils/url-base64-to-uint8-array';
+
+export default Component.extend({
+
+  botkaURL: null,
+  username: null,
+  subscribed: false,
+
+  webPushBaseURL: computed('botkaURL', function() {
+    return this.botkaURL + '/web-push';
+  }),
+
+  init () {
+    this._super(...arguments);
+
+    navigator.serviceWorker.ready.then(registration => {
+      return registration.pushManager.getSubscription();
+    }).then(subscription => {
+      if (subscription) { this.set('subscribed', true); }
+    });
+  },
+
+  actions: {
+
+    subscribe () {
+      navigator.serviceWorker.ready.then(async function(registration) {
+        // Get the server's public key
+        const response = await fetch(this.webPushBaseURL+'/vapid-public-key');
+        const vapidPublicKey = await response.text();
+        // Chrome doesn't accept the base64-encoded (string) vapidPublicKey yet
+        // urlBase64ToUint8Array() is defined in /tools.js
+        const convertedVapidKey = urlBase64ToUint8Array(vapidPublicKey);
+        // Subscribe the user
+        return registration.pushManager.subscribe({
+          userVisibleOnly: true,
+          applicationServerKey: convertedVapidKey
+        });
+      }.bind(this)).then(subscription => {
+        console.debug('Subscribed', subscription.endpoint);
+        return fetch(this.webPushBaseURL+'/register', {
+          method: 'post',
+          headers: { 'Content-type': 'application/json' },
+          body: JSON.stringify({
+            user: this.username,
+            subscription: subscription
+          })
+        });
+      }).then(this.set('subscribed', true));
+    },
+
+    unsubscribe () {
+      navigator.serviceWorker.ready.then(registration => {
+        return registration.pushManager.getSubscription();
+      }).then(subscription => {
+        return subscription.unsubscribe()
+          .then(() => {
+            console.debug('Unsubscribed', subscription.endpoint);
+            return fetch(this.webPushBaseURL+'/unregister', {
+              method: 'post',
+              headers: { 'Content-type': 'application/json' },
+              body: JSON.stringify({ subscription: subscription })
+            });
+          });
+      }).then(this.set('subscribed', false));
+    }
+
+  }
+
+});

--- a/app/components/web-push-subscription/template.hbs
+++ b/app/components/web-push-subscription/template.hbs
@@ -1,0 +1,11 @@
+<p>
+  <i>username:</i> {{username}}<br>
+  <i>base URL:</i> {{webPushBaseURL}}
+</p>
+<p>
+  {{#if subscribed}}
+    <button {{action "unsubscribe"}}>Disable push notifications</button>
+  {{else}}
+    <button {{action "subscribe"}}>Receive push notifications</button>
+  {{/if}}
+</p>

--- a/app/models/space.js
+++ b/app/models/space.js
@@ -8,6 +8,7 @@ export default EmberObject.extend({
   protocol: 'IRC',
   server  : null,
   channels: null, // Channel instances
+  botkaURL: null, // Kosmos bot
 
   // Keep a list of all old sockethubPersonIds, because there might
   // still be coming events from Sockethub for those.
@@ -96,7 +97,8 @@ export default EmberObject.extend({
         secure: this.get('server.secure'),
         nickname: this.get('server.nickname')
       },
-      channels: this.channelNames || []
+      channels: this.channelNames || [],
+      botkaURL: this.botkaURL || null
     };
 
     ['username', 'password', 'nickname'].forEach(prop => {

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -1,5 +1,6 @@
 import Route from '@ember/routing/route';
 import { storageFor as localStorageFor } from 'ember-local-storage';
+import config from 'hyperchannel/config/environment';
 
 export default Route.extend({
 

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -6,8 +6,8 @@ export default Route.extend({
   userSettings: localStorageFor('user-settings'),
 
   redirect() {
-    let currentSpace = this.get('userSettings.currentSpace') || 'freenode';
-    let currentChannel = this.get('userSettings.currentChannel') || '#kosmos';
+    let currentSpace = this.get('userSettings.currentSpace') || config.defaultSpaceId;
+    let currentChannel = this.get('userSettings.currentChannel') || 'kosmos';
 
     if (currentSpace && currentChannel) {
       this.transitionTo('space.channel', currentSpace, currentChannel);

--- a/app/routes/space.js
+++ b/app/routes/space.js
@@ -6,8 +6,7 @@ export default Route.extend({
   coms: service(),
 
   model: function(params) {
-    return this.coms.get('spaces')
-                          .findBy('id', params.id);
+    return this.coms.get('spaces').findBy('id', params.id);
   }
 
 });

--- a/app/services/coms.js
+++ b/app/services/coms.js
@@ -69,7 +69,8 @@ export default Service.extend({
               id: id,
               name: spaceData[id].name,
               protocol: spaceData[id].protocol,
-              server: spaceData[id].server
+              server: spaceData[id].server,
+              botkaURL: spaceData[id].botkaURL
             });
             this.connectAndAddSpace(space);
             this.instantiateChannels(space, spaceData[id].channels);

--- a/app/services/remotestorage.js
+++ b/app/services/remotestorage.js
@@ -2,6 +2,7 @@ import Service from '@ember/service';
 import Space from 'hyperchannel/models/space';
 import RemoteStorage from 'npm:remotestoragejs';
 import Kosmos from 'npm:remotestorage-module-kosmos';
+import config from 'hyperchannel/config/environment';
 
 export default Service.extend({
 
@@ -18,26 +19,25 @@ export default Service.extend({
   },
 
   addDefaultSpace() {
-    let nickname = window.prompt("Choose a nickname");
+    let spaceConfig = config.spacePresets
+                            .find(s => s.id === config.defaultSpaceId);
 
     let params = {
-      id: 'freenode',
-      name: 'Freenode',
-      protocol: 'IRC',
-      server: {
-        hostname: 'irc.freenode.net',
-        secure: true,
-        port: 7000,
-        nickname: nickname
-      },
+      id: spaceConfig.id,
+      name: spaceConfig.name,
+      protocol: spaceConfig.protocol,
+      server: spaceConfig.server,
       channels: [
         '#hackerbeach',
         '#kosmos',
         '#kosmos-dev',
         '#kosmos-random',
         '#sockethub'
-      ]
+      ],
+      botkaURL: 'http://localhost:4242'
     };
+
+    params.server.nickname = window.prompt("Choose a nickname");
 
     return this.rs.kosmos.spaces.store(params)
       .then(() => {
@@ -59,7 +59,6 @@ export default Service.extend({
   },
 
   removeSpace(space) {
-    // TODO this is buggy in the current rs.js beta branch
     return this.rs.kosmos.spaces.remove(space.get('id'))
       .then(() => console.debug('[remotestorage]', `removed space ${space.get('name')} from RS`));
   }

--- a/app/services/remotestorage.js
+++ b/app/services/remotestorage.js
@@ -34,7 +34,7 @@ export default Service.extend({
         '#kosmos-random',
         '#sockethub'
       ],
-      botkaURL: 'http://localhost:4242'
+      botkaURL: spaceConfig.botkaURL
     };
 
     params.server.nickname = window.prompt("Choose a nickname");

--- a/app/storages/user-settings.js
+++ b/app/storages/user-settings.js
@@ -1,13 +1,13 @@
 import StorageObject from 'ember-local-storage/local/object';
+import config from 'hyperchannel/config/environment';
 
 const Storage = StorageObject.extend();
 
-// Uncomment if you would like to set initialState
 Storage.reopenClass({
   initialState() {
     return {
       nickname: null,
-      currentSpace: 'freenode',
+      currentSpace: config.defaultSpaceId,
       currentChannel: 'kosmos'
     };
   }

--- a/app/styles/_buttons.scss
+++ b/app/styles/_buttons.scss
@@ -1,0 +1,3 @@
+button, input[type=submit] {
+  padding: 0.3rem 0.6rem;
+}

--- a/app/styles/_layout.scss
+++ b/app/styles/_layout.scss
@@ -98,7 +98,7 @@ div#channel {
   }
 }
 
-section#settings {
+section#settings, section#space {
   flex: 1;
   overflow: auto;
 }

--- a/app/styles/_space.scss
+++ b/app/styles/_space.scss
@@ -1,0 +1,19 @@
+section#space {
+
+  background-color: #fff;
+  color: #333;
+  padding: $headerHeight 3rem 1.5rem;
+
+  p {
+    margin-bottom: 1em;
+  }
+
+  header {
+    margin-bottom: 3rem;
+  }
+
+  h2 {
+    font-size: 2rem;
+  }
+
+}

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -191,8 +191,9 @@ header {
   color: #aaa;
 }
 
-@import "layout";
 @import "iconfont";
+@import "layout";
+@import "buttons";
 @import "components/channel-nav";
 @import "components/channel-container";
 @import "components/message-chat";
@@ -200,3 +201,4 @@ header {
 @import "components/notification-topic-change";
 @import "components/modal-target";
 @import "settings";
+@import "space";

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -185,6 +185,9 @@ header {
 
 .no-messages {
   margin-top: 10px;
+}
+
+.discreet {
   color: #aaa;
 }
 

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -1,1 +1,0 @@
-<p>[index.hbs]</p>

--- a/app/templates/space/index.hbs
+++ b/app/templates/space/index.hbs
@@ -1,0 +1,12 @@
+<section id="space">
+  <header>
+    <h2>{{model.name}}</h2>
+    <p class="discreet">{{model.server.hostname}}</p>
+  </header>
+  <div class="content">
+    <p>
+      {{web-push-subscription botkaURL=model.botkaURL
+                              username=model.userNickname}}
+    </p>
+  </div>
+</section>

--- a/app/utils/url-base64-to-uint8-array.js
+++ b/app/utils/url-base64-to-uint8-array.js
@@ -1,0 +1,17 @@
+export default function urlBase64ToUint8Array(base64String) {
+
+  let padding = '='.repeat((4 - base64String.length % 4) % 4);
+  let base64 = (base64String + padding)
+    .replace(/-/g, '+')
+    .replace(/_/g, '/');
+
+  let rawData = window.atob(base64);
+  let outputArray = new Uint8Array(rawData.length);
+
+  for (let i = 0; i < rawData.length; ++i) {
+    outputArray[i] = rawData.charCodeAt(i);
+  }
+
+  return outputArray;
+
+}

--- a/config/environment.js
+++ b/config/environment.js
@@ -25,45 +25,12 @@ module.exports = function(environment) {
     spacePresets: spacePresets
   };
 
-  //
-  // Service Worker
-  //
-  ENV.serviceWorker = {
-    enabled: false,
-    includeRegistration: false,
-    debug: true,
-    // precacheURLs: [
-    // ],
-    networkFirstURLs: [
-      /activity-streams\.js/,
-      /socket\.io\.js/,
-      /sockethub-client\.js/
-    ],
-    excludePaths: [/test.*/, 'robots.txt', 'crossdomain.xml']
-    // fallback: [
-    //   '/online.html /offline.html'
-    // ],
-    // serviceWorkerFile: "service-worker.js",
-    // skipWaiting: true,
-    // swIncludeFiles: [
-    //   'bower_components/pouchdb/dist/pouchdb.js'
-    // ],
-    // swEnvironment: {
-    // }
-  };
-
   if (environment === 'development') {
-    // ENV.serviceWorker.enabled = true;
-    // ENV.serviceWorker.includeRegistration = true;
-    // ENV.serviceWorker.debug = true;
     // ENV.APP.LOG_RESOLVER = true;
     // ENV.APP.LOG_ACTIVE_GENERATION = true;
     // ENV.APP.LOG_TRANSITIONS = true;
     // ENV.APP.LOG_TRANSITIONS_INTERNAL = true;
     // ENV.APP.LOG_VIEW_LOOKUPS = true;
-
-    // ENV.serviceWorker.enabled = true;
-    // ENV.serviceWorker.includeRegistration = true;
   }
 
   if (environment === 'test') {
@@ -80,9 +47,6 @@ module.exports = function(environment) {
 
   if (environment === 'production') {
     ENV.sockethubURL = 'https://sockethub.kosmos.org:10550';
-
-    ENV.serviceWorker.enabled = true;
-    ENV.serviceWorker.includeRegistration = true;
   }
 
   return ENV;

--- a/config/environment.js
+++ b/config/environment.js
@@ -22,7 +22,8 @@ module.exports = function(environment) {
     },
     sockethubURL: 'http://localhost:10550',
     publicLogsUrl: 'https://storage.5apps.com/kosmos/public/chat-messages',
-    spacePresets: spacePresets
+    spacePresets: spacePresets,
+    defaultSpaceId:'irc-localhost'
   };
 
   if (environment === 'development') {
@@ -46,6 +47,7 @@ module.exports = function(environment) {
   }
 
   if (environment === 'production') {
+    ENV.defaultSpaceId = 'freenode';
     ENV.sockethubURL = 'https://sockethub.kosmos.org:10550';
   }
 

--- a/config/space-presets.json
+++ b/config/space-presets.json
@@ -9,7 +9,8 @@
       "hostname": "irc.freenode.net",
       "secure": true,
       "port": 7000
-    }
+    },
+    "botkaURL": "https://freenode.botka.kosmos.org"
   },
   {
     "id": "moznet",
@@ -33,6 +34,18 @@
       "hostname": "irc.gnome.org",
       "secure": true,
       "port": 6697
+    }
+  },
+  {
+    "id": "irc-localhost",
+    "name": "IRC localhost",
+    "description": "Local IRC server for development",
+    "website": "",
+    "protocol": "IRC",
+    "server": {
+      "hostname": "localhost",
+      "secure": false,
+      "port": 6667
     }
   },
   {

--- a/config/space-presets.json
+++ b/config/space-presets.json
@@ -47,6 +47,8 @@
       "secure": false,
       "port": 6667
     }
+    },
+    "botkaURL": "http://localhost:4242"
   },
   {
     "id": "xmpp-localhost",

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -43,7 +43,10 @@ module.exports = function(defaults) {
           }
         ]
       }
-    }
+    },
+    // 'ember-service-worker': {
+    //   enabled: false
+    // }
   });
 
   // Use `app.import` to add additional libraries to the generated

--- a/package-lock.json
+++ b/package-lock.json
@@ -2173,19 +2173,62 @@
         }
       }
     },
-    "broccoli-serviceworker": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/broccoli-serviceworker/-/broccoli-serviceworker-0.1.6.tgz",
-      "integrity": "sha1-ES/4pNEs4C37m4G/oh33gl80Yyw=",
+    "broccoli-rollup": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/broccoli-rollup/-/broccoli-rollup-0.0.4.tgz",
+      "integrity": "sha1-0jsu+PvYDoXbtH01D9q3KQLNF8Q=",
       "dev": true,
       "requires": {
-        "broccoli-funnel": "1.0.9",
-        "broccoli-kitchen-sink-helpers": "0.3.1",
-        "broccoli-merge-trees": "1.1.5",
-        "broccoli-writer": "0.1.1",
-        "rsvp": "3.6.2",
-        "stringifile": "0.1.1",
-        "sw-toolbox": "3.4.0"
+        "broccoli-caching-writer": "2.3.1",
+        "rollup": "0.26.7"
+      },
+      "dependencies": {
+        "broccoli-caching-writer": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/broccoli-caching-writer/-/broccoli-caching-writer-2.3.1.tgz",
+          "integrity": "sha1-uTz1j5Jk8AMHWGjbBXdPTn8lvQc=",
+          "dev": true,
+          "requires": {
+            "broccoli-kitchen-sink-helpers": "0.2.9",
+            "broccoli-plugin": "1.1.0",
+            "debug": "2.6.8",
+            "rimraf": "2.6.2",
+            "rsvp": "3.6.2",
+            "walk-sync": "0.2.7"
+          }
+        },
+        "broccoli-kitchen-sink-helpers": {
+          "version": "0.2.9",
+          "resolved": "https://registry.npmjs.org/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.2.9.tgz",
+          "integrity": "sha1-peCYbtjXb7WYS2jD8EUNOpbjbsw=",
+          "dev": true,
+          "requires": {
+            "glob": "5.0.15",
+            "mkdirp": "0.5.1"
+          }
+        },
+        "broccoli-plugin": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.1.0.tgz",
+          "integrity": "sha1-c+LPoF+OoeP8FCDEDD2efcckvwI=",
+          "dev": true,
+          "requires": {
+            "promise-map-series": "0.2.3",
+            "quick-temp": "0.1.8",
+            "rimraf": "2.6.2",
+            "symlink-or-copy": "1.1.8"
+          }
+        },
+        "walk-sync": {
+          "version": "0.2.7",
+          "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.2.7.tgz",
+          "integrity": "sha1-tJvk7mhnZXrrc2l4tWop0Q+jmWk=",
+          "dev": true,
+          "requires": {
+            "ensure-posix-path": "1.0.2",
+            "matcher-collection": "1.0.5"
+          }
+        }
       }
     },
     "broccoli-slow-trees": {
@@ -6370,6 +6413,411 @@
         "recast": "0.11.23"
       }
     },
+    "ember-service-worker": {
+      "version": "0.6.12",
+      "resolved": "https://registry.npmjs.org/ember-service-worker/-/ember-service-worker-0.6.12.tgz",
+      "integrity": "sha512-9/vJMrSFlf73bYLNKIui7Ez7x4cRu9CFWTn1DMZDUCwKs1YbsNvV2bzmh70YhFOsb2YGPY3erXDJGnb2l2lesQ==",
+      "dev": true,
+      "requires": {
+        "broccoli-babel-transpiler": "5.7.4",
+        "broccoli-caching-writer": "3.0.3",
+        "broccoli-file-creator": "1.1.1",
+        "broccoli-funnel": "1.0.9",
+        "broccoli-merge-trees": "1.1.1",
+        "broccoli-rollup": "0.0.4",
+        "broccoli-uglify-sourcemap": "1.5.2",
+        "clone": "1.0.4",
+        "ember-cli-babel": "5.2.8",
+        "exists-sync": "0.0.3",
+        "glob": "7.1.2",
+        "hash-for-dep": "1.2.3",
+        "rollup-plugin-replace": "1.2.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "babel-core": {
+          "version": "5.8.38",
+          "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.38.tgz",
+          "integrity": "sha1-H8ruedfmG3ULALjlT238nQr4ZVg=",
+          "dev": true,
+          "requires": {
+            "babel-plugin-constant-folding": "1.0.1",
+            "babel-plugin-dead-code-elimination": "1.0.2",
+            "babel-plugin-eval": "1.0.1",
+            "babel-plugin-inline-environment-variables": "1.0.1",
+            "babel-plugin-jscript": "1.0.4",
+            "babel-plugin-member-expression-literals": "1.0.1",
+            "babel-plugin-property-literals": "1.0.1",
+            "babel-plugin-proto-to-assign": "1.0.4",
+            "babel-plugin-react-constant-elements": "1.0.3",
+            "babel-plugin-react-display-name": "1.0.3",
+            "babel-plugin-remove-console": "1.0.1",
+            "babel-plugin-remove-debugger": "1.0.1",
+            "babel-plugin-runtime": "1.0.7",
+            "babel-plugin-undeclared-variables-check": "1.0.2",
+            "babel-plugin-undefined-to-void": "1.1.6",
+            "babylon": "5.8.38",
+            "bluebird": "2.11.0",
+            "chalk": "1.1.3",
+            "convert-source-map": "1.5.0",
+            "core-js": "1.2.7",
+            "debug": "2.6.8",
+            "detect-indent": "3.0.1",
+            "esutils": "2.0.2",
+            "fs-readdir-recursive": "0.1.2",
+            "globals": "6.4.1",
+            "home-or-tmp": "1.0.0",
+            "is-integer": "1.0.7",
+            "js-tokens": "1.0.1",
+            "json5": "0.4.0",
+            "lodash": "3.10.1",
+            "minimatch": "2.0.10",
+            "output-file-sync": "1.1.2",
+            "path-exists": "1.0.0",
+            "path-is-absolute": "1.0.1",
+            "private": "0.1.7",
+            "regenerator": "0.8.40",
+            "regexpu": "1.3.0",
+            "repeating": "1.1.3",
+            "resolve": "1.4.0",
+            "shebang-regex": "1.0.0",
+            "slash": "1.0.0",
+            "source-map": "0.5.7",
+            "source-map-support": "0.2.10",
+            "to-fast-properties": "1.0.3",
+            "trim-right": "1.0.1",
+            "try-resolve": "1.0.1"
+          }
+        },
+        "babylon": {
+          "version": "5.8.38",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-5.8.38.tgz",
+          "integrity": "sha1-7JsSCxG/bM1Bc6GL8hfmC3mFn/0=",
+          "dev": true
+        },
+        "bluebird": {
+          "version": "2.11.0",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
+          "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE=",
+          "dev": true
+        },
+        "broccoli-babel-transpiler": {
+          "version": "5.7.4",
+          "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-5.7.4.tgz",
+          "integrity": "sha512-gI14Pqc4qbmn5RW4SuAmybLiOoYW59D+HzQyhY6WdaGMAjikKBwJN0p17phyvafQ+kvG0mUiMd83lgHLeATnEA==",
+          "dev": true,
+          "requires": {
+            "babel-core": "5.8.38",
+            "broccoli-funnel": "1.0.9",
+            "broccoli-merge-trees": "1.1.1",
+            "broccoli-persistent-filter": "1.4.3",
+            "clone": "0.2.0",
+            "hash-for-dep": "1.2.3",
+            "heimdalljs-logger": "0.1.9",
+            "json-stable-stringify": "1.0.1",
+            "rsvp": "3.6.2",
+            "workerpool": "2.3.0"
+          },
+          "dependencies": {
+            "clone": {
+              "version": "0.2.0",
+              "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
+              "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=",
+              "dev": true
+            }
+          }
+        },
+        "broccoli-merge-trees": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-1.1.1.tgz",
+          "integrity": "sha1-Hig9GMaG2pIruRqA16rA0WE4jiE=",
+          "dev": true,
+          "requires": {
+            "broccoli-plugin": "1.3.0",
+            "can-symlink": "1.0.0",
+            "debug": "2.6.8",
+            "fast-ordered-set": "1.0.3",
+            "fs-tree-diff": "0.4.4",
+            "rimraf": "2.6.2",
+            "symlink-or-copy": "1.1.8"
+          }
+        },
+        "broccoli-uglify-sourcemap": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/broccoli-uglify-sourcemap/-/broccoli-uglify-sourcemap-1.5.2.tgz",
+          "integrity": "sha1-BPhKsNtTkDH6hozPpWPJky1Qzts=",
+          "dev": true,
+          "requires": {
+            "broccoli-plugin": "1.3.0",
+            "debug": "2.6.8",
+            "lodash.merge": "4.6.0",
+            "matcher-collection": "1.0.5",
+            "mkdirp": "0.5.1",
+            "source-map-url": "0.3.0",
+            "symlink-or-copy": "1.1.8",
+            "uglify-js": "2.8.29",
+            "walk-sync": "0.1.3"
+          }
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "clone": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+          "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
+          "dev": true
+        },
+        "core-js": {
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
+          "dev": true
+        },
+        "detect-indent": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
+          "integrity": "sha1-ncXl3bzu+DJXZLlFGwK8bVQIT3U=",
+          "dev": true,
+          "requires": {
+            "get-stdin": "4.0.1",
+            "minimist": "1.2.0",
+            "repeating": "1.1.3"
+          }
+        },
+        "ember-cli-babel": {
+          "version": "5.2.8",
+          "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-5.2.8.tgz",
+          "integrity": "sha512-Mt9OOB5RaZwjde+LYef8EgwNVCAzsYDv4ktshblaXxr4m/Xm5/7/rxEu42RNrYkoy/qWpT9uhaD+JKK4riMf+w==",
+          "dev": true,
+          "requires": {
+            "broccoli-babel-transpiler": "5.7.4",
+            "broccoli-funnel": "1.0.9",
+            "clone": "2.1.1",
+            "ember-cli-version-checker": "1.3.1",
+            "resolve": "1.4.0"
+          },
+          "dependencies": {
+            "clone": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
+              "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs=",
+              "dev": true
+            }
+          }
+        },
+        "ember-cli-version-checker": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-1.3.1.tgz",
+          "integrity": "sha1-C8LRNMgwFC2mS/lieg7e0QthrnI=",
+          "dev": true,
+          "requires": {
+            "semver": "5.4.1"
+          }
+        },
+        "exists-sync": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/exists-sync/-/exists-sync-0.0.3.tgz",
+          "integrity": "sha1-uRAAC+27ETs3i4L19adjgQdiLc8=",
+          "dev": true
+        },
+        "fs-tree-diff": {
+          "version": "0.4.4",
+          "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.4.4.tgz",
+          "integrity": "sha1-9rddcNsiwfOwXVkicPTtbJwvgt0=",
+          "dev": true,
+          "requires": {
+            "debug": "2.6.8",
+            "fast-ordered-set": "1.0.3"
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          },
+          "dependencies": {
+            "minimatch": {
+              "version": "3.0.4",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+              "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+              "dev": true,
+              "requires": {
+                "brace-expansion": "1.1.8"
+              }
+            }
+          }
+        },
+        "globals": {
+          "version": "6.4.1",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-6.4.1.tgz",
+          "integrity": "sha1-hJgDKzttHMge68X3lpDY/in6v08=",
+          "dev": true
+        },
+        "hash-for-dep": {
+          "version": "1.2.3",
+          "resolved": "https://registry.npmjs.org/hash-for-dep/-/hash-for-dep-1.2.3.tgz",
+          "integrity": "sha512-NE//rDaCFpWHViw30YM78OAGBShU+g4dnUGY3UWGyEzPOGYg/ptOjk32nEc+bC1xz+RfK5UIs6lOL6eQdrV4Ow==",
+          "dev": true,
+          "requires": {
+            "broccoli-kitchen-sink-helpers": "0.3.1",
+            "heimdalljs": "0.2.5",
+            "heimdalljs-logger": "0.1.9",
+            "resolve": "1.4.0"
+          }
+        },
+        "home-or-tmp": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
+          "integrity": "sha1-S58eQIAMPlDGwn94FnavzOcfOYU=",
+          "dev": true,
+          "requires": {
+            "os-tmpdir": "1.0.2",
+            "user-home": "1.1.1"
+          }
+        },
+        "js-tokens": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.1.tgz",
+          "integrity": "sha1-zENaXIuUrRWst5gxQPyAGCyJrq4=",
+          "dev": true
+        },
+        "json5": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
+          "integrity": "sha1-BUNS5MTIDIbAkjh31EneF2pzLI0=",
+          "dev": true
+        },
+        "lodash": {
+          "version": "3.10.1",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
+          "dev": true
+        },
+        "minimatch": {
+          "version": "2.0.10",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+          "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        },
+        "path-exists": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz",
+          "integrity": "sha1-1aiZjrce83p0w06w2eum6HjuoIE=",
+          "dev": true
+        },
+        "repeating": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+          "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
+          "dev": true,
+          "requires": {
+            "is-finite": "1.0.2"
+          }
+        },
+        "source-map-support": {
+          "version": "0.2.10",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
+          "integrity": "sha1-6lo5AKHByyUJagrozFwrSxDe09w=",
+          "dev": true,
+          "requires": {
+            "source-map": "0.1.32"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.1.32",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
+              "integrity": "sha1-yLbBZ3l7pHQKjqMyUhYv8IWRsmY=",
+              "dev": true,
+              "requires": {
+                "amdefine": "1.0.1"
+              }
+            }
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        },
+        "walk-sync": {
+          "version": "0.1.3",
+          "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.1.3.tgz",
+          "integrity": "sha1-igcmGgC9ps+xviXp8QD61XVG9YM=",
+          "dev": true
+        },
+        "workerpool": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-2.3.0.tgz",
+          "integrity": "sha512-JP5DpviEV84zDmz13QnD4FfRjZBjnTOYY2O4pGgxtlqLh47WOzQFHm8o17TE5OSfcDoKC6vHSrN4yPju93DW0Q==",
+          "dev": true,
+          "requires": {
+            "object-assign": "4.1.1"
+          }
+        }
+      }
+    },
+    "ember-service-worker-cache-first": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/ember-service-worker-cache-first/-/ember-service-worker-cache-first-0.6.2.tgz",
+      "integrity": "sha1-QTzZQOWw7yysE/Q4iC0Y/pFLC0M=",
+      "dev": true,
+      "requires": {
+        "broccoli-merge-trees": "1.2.4",
+        "broccoli-plugin": "1.3.0"
+      },
+      "dependencies": {
+        "broccoli-merge-trees": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-1.2.4.tgz",
+          "integrity": "sha1-oAFRm7UGfwZYnZGvopQkRaLQ/bU=",
+          "dev": true,
+          "requires": {
+            "broccoli-plugin": "1.3.0",
+            "can-symlink": "1.0.0",
+            "fast-ordered-set": "1.0.3",
+            "fs-tree-diff": "0.5.6",
+            "heimdalljs": "0.2.5",
+            "heimdalljs-logger": "0.1.9",
+            "rimraf": "2.6.2",
+            "symlink-or-copy": "1.1.8"
+          }
+        }
+      }
+    },
     "ember-sinon": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/ember-sinon/-/ember-sinon-2.1.0.tgz",
@@ -7037,6 +7485,12 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
       "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+      "dev": true
+    },
+    "estree-walker": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.3.1.tgz",
+      "integrity": "sha1-5rGlHPcpJSTnI3wxLl/mZgwc4ao=",
       "dev": true
     },
     "esutils": {
@@ -11055,6 +11509,15 @@
         "yallist": "2.1.2"
       }
     },
+    "magic-string": {
+      "version": "0.22.5",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.22.5.tgz",
+      "integrity": "sha512-oreip9rJZkzvA8Qzk9HFs8fZGF/u7H/gtrE8EN6RjKJ9kh2HlC+yQ2QezifqTZfGyiuAV0dRv5a+y/8gBb1m9w==",
+      "dev": true,
+      "requires": {
+        "vlq": "0.2.3"
+      }
+    },
     "make-dir": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.2.0.tgz",
@@ -13583,6 +14046,71 @@
         }
       }
     },
+    "rollup": {
+      "version": "0.26.7",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.26.7.tgz",
+      "integrity": "sha1-EodbyDoO6N3PSzvPMPK3fWBlLdc=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "minimist": "1.2.0",
+        "source-map-support": "0.4.18"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
+      }
+    },
+    "rollup-plugin-replace": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-replace/-/rollup-plugin-replace-1.2.1.tgz",
+      "integrity": "sha512-l9Pgb7bh5Wx18+qM9iOWZ/CKcwyKJETLAwCh6bjKwTOgTzNH3KmKDWI/X/ToNA7fA/68chhFyvISvreRxWFVtw==",
+      "dev": true,
+      "requires": {
+        "magic-string": "0.22.5",
+        "minimatch": "3.0.4",
+        "rollup-pluginutils": "2.0.1"
+      }
+    },
+    "rollup-pluginutils": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.0.1.tgz",
+      "integrity": "sha1-fslbNXP2VDpGpkYb2afFRFJdD8A=",
+      "dev": true,
+      "requires": {
+        "estree-walker": "0.3.1",
+        "micromatch": "2.3.11"
+      }
+    },
     "rsvp": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
@@ -14145,12 +14673,6 @@
         "parseurl": "1.3.2",
         "send": "0.16.2"
       }
-    },
-    "serviceworker-cache-polyfill": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/serviceworker-cache-polyfill/-/serviceworker-cache-polyfill-4.0.0.tgz",
-      "integrity": "sha1-3hnuc77yGrPAdAo3sz22JGS6ves=",
-      "dev": true
     },
     "set-blocking": {
       "version": "2.0.0",
@@ -14932,12 +15454,6 @@
       "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
       "dev": true
     },
-    "stringifile": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/stringifile/-/stringifile-0.1.1.tgz",
-      "integrity": "sha1-hbxmzc/qy1k4vAe0JcFCoWKHRV4=",
-      "dev": true
-    },
     "stringmap": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/stringmap/-/stringmap-0.2.2.tgz",
@@ -15061,16 +15577,6 @@
       "dev": true,
       "requires": {
         "has-flag": "2.0.0"
-      }
-    },
-    "sw-toolbox": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/sw-toolbox/-/sw-toolbox-3.4.0.tgz",
-      "integrity": "sha1-oW7+z0p57TIZHPGSNSXy7om8dtw=",
-      "dev": true,
-      "requires": {
-        "path-to-regexp": "1.7.0",
-        "serviceworker-cache-polyfill": "4.0.0"
       }
     },
     "symlink-or-copy": {
@@ -15633,7 +16139,6 @@
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
       "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
       "dev": true,
-      "optional": true,
       "requires": {
         "source-map": "0.5.7",
         "uglify-to-browserify": "1.0.2",
@@ -15644,15 +16149,13 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
           "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "cliui": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
           "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
           "dev": true,
-          "optional": true,
           "requires": {
             "center-align": "0.1.3",
             "right-align": "0.1.3",
@@ -15663,15 +16166,13 @@
           "version": "0.0.2",
           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
           "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yargs": {
           "version": "3.10.0",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
           "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
           "dev": true,
-          "optional": true,
           "requires": {
             "camelcase": "1.2.1",
             "cliui": "2.1.0",
@@ -16051,6 +16552,12 @@
         "extsprintf": "1.3.0"
       }
     },
+    "vlq": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/vlq/-/vlq-0.2.3.tgz",
+      "integrity": "sha512-DRibZL6DsNhIgYQ+wNdWDL2SL3bKPlVrRiBqV5yuMm++op8W4kGFtaQfCs4KEJn0wBZcHVHJ3eoywX8983k1ow==",
+      "dev": true
+    },
     "vm-browserify": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
@@ -16186,8 +16693,7 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
       "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "wordwrap": {
       "version": "0.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6790,33 +6790,9 @@
         }
       }
     },
-    "ember-service-worker-cache-first": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/ember-service-worker-cache-first/-/ember-service-worker-cache-first-0.6.2.tgz",
-      "integrity": "sha1-QTzZQOWw7yysE/Q4iC0Y/pFLC0M=",
-      "dev": true,
-      "requires": {
-        "broccoli-merge-trees": "1.2.4",
-        "broccoli-plugin": "1.3.0"
-      },
-      "dependencies": {
-        "broccoli-merge-trees": {
-          "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-1.2.4.tgz",
-          "integrity": "sha1-oAFRm7UGfwZYnZGvopQkRaLQ/bU=",
-          "dev": true,
-          "requires": {
-            "broccoli-plugin": "1.3.0",
-            "can-symlink": "1.0.0",
-            "fast-ordered-set": "1.0.3",
-            "fs-tree-diff": "0.5.6",
-            "heimdalljs": "0.2.5",
-            "heimdalljs-logger": "0.1.9",
-            "rimraf": "2.6.2",
-            "symlink-or-copy": "1.1.8"
-          }
-        }
-      }
+    "ember-service-worker-hubot-web-push-notifications": {
+      "version": "github:67P/ember-service-worker-hubot-web-push-notifications#84a8c9a7066f819849a38e07a2e427be884cb008",
+      "dev": true
     },
     "ember-sinon": {
       "version": "2.1.0",
@@ -13828,9 +13804,9 @@
       }
     },
     "remotestorage-module-kosmos": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/remotestorage-module-kosmos/-/remotestorage-module-kosmos-1.0.0.tgz",
-      "integrity": "sha1-q2zoWE99W2iJFJIe16EN/4huaTs=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/remotestorage-module-kosmos/-/remotestorage-module-kosmos-1.1.0.tgz",
+      "integrity": "sha512-0kjvrGYlMW/WgJQmMsMK9UIDMg7ti3dd/7VzmwyW8g3IOf3gMtpLEY0zcr0QLMKxNFGzEzIpn/cSG4Q16Q8o6w==",
       "dev": true
     },
     "remotestoragejs": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "autoprefixer": "^7.0.1",
     "bourbon": "^4.3.4",
     "broccoli-asset-rev": "^2.5.0",
-    "broccoli-serviceworker": "0.1.6",
     "ember-ajax": "^3.0.0",
     "ember-browserify": "^1.2.2",
     "ember-cli": "~3.1.2",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,8 @@
     "ember-polyfill-for-tests": "0.2.0",
     "ember-resolver": "^4.0.0",
     "ember-route-action-helper": "2.0.3",
+    "ember-service-worker": "^0.6.12",
+    "ember-service-worker-hubot-web-push-notifications": "^1.0.0",
     "ember-sinon": "^2.1.0",
     "ember-sinon-qunit": "^3.1.0",
     "ember-source": "~3.1.0",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "ember-resolver": "^4.0.0",
     "ember-route-action-helper": "2.0.3",
     "ember-service-worker": "^0.6.12",
-    "ember-service-worker-hubot-web-push-notifications": "^1.0.0",
+    "ember-service-worker-hubot-web-push-notifications": "67P/ember-service-worker-hubot-web-push-notifications",
     "ember-sinon": "^2.1.0",
     "ember-sinon-qunit": "^3.1.0",
     "ember-source": "~3.1.0",
@@ -73,7 +73,7 @@
     "linkifyjs": "^2.1.6",
     "liquid-fire": "0.29.2",
     "loader.js": "^4.2.3",
-    "remotestorage-module-kosmos": "^1.0.0",
+    "remotestorage-module-kosmos": "^1.1.0",
     "remotestoragejs": "^1.0.3"
   }
 }

--- a/tests/integration/components/web-push-subscription/component-test.js
+++ b/tests/integration/components/web-push-subscription/component-test.js
@@ -1,0 +1,18 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | web-push-subscription', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it shows the correct button', async function(assert) {
+    this.set('subscribed', false);
+    await render(hbs`{{web-push-subscription subscribed=subscribed}}`);
+    assert.ok(this.$('button')[0].innerText.match('Receive'));
+
+    this.set('subscribed', true);
+    await render(hbs`{{web-push-subscription subscribed=subscribed}}`);
+    assert.ok(this.$('button')[0].innerText.match('Disable'));
+  });
+});


### PR DESCRIPTION
For the default Freenode space to work with this, it still needs a change on the dev server to be configured via Chef, but I'm sitting in a train currently.

In general, this subscribes to notifications via the API provided by [hubot-web-push-notifications](https://github.com/67P/hubot-web-push-notifications/), a Hubot script which I wrote a short while ago, and which will notify subscribed users of mentions, when their username is not currently online. (That means it will not work if you're online via a bouncer or sth.)

One general issue we'll have to solve is how a client can automatically discover Kosmos agents/bots/logs. I has the idea of setting up some kind of transparent directory service, which is easy to contribute to. This would also apply to finding and easily connecting to servers/networks in general, not just special services on them, like these push notifications. Maybe someone else had similar ideas?

refs #2