### PR TITLE
Easy username mentions

### DIFF
--- a/app/components/channel-container/component.js
+++ b/app/components/channel-container/component.js
@@ -69,12 +69,13 @@ export default Component.extend({
 
     addUsernameMentionToMessage (username) {
       const msg = this.newMessage;
-      if (msg.match(new RegExp(`^${username}`))) {
-        // new message already starts with username
-        return false;
-      } else {
+
+      if (! msg.match(new RegExp(`^${username}`))) {
         this.set('newMessage', `${username}: ${msg}`)
       }
+
+      let inputEl = this.$('#message-field').get(0);
+      inputEl.focus();
     }
 
   }

--- a/app/components/channel-container/component.js
+++ b/app/components/channel-container/component.js
@@ -65,6 +65,16 @@ export default Component.extend({
       }).finally(() => {
         this.set('scrollingDisabled', false);
       });
+    },
+
+    addUsernameMentionToMessage (username) {
+      const msg = this.newMessage;
+      if (msg.match(new RegExp(`^${username}`))) {
+        // new message already starts with username
+        return false;
+      } else {
+        this.set('newMessage', `${username}: ${msg}`)
+      }
     }
 
   }

--- a/app/components/channel-container/component.js
+++ b/app/components/channel-container/component.js
@@ -40,6 +40,11 @@ export default Component.extend({
     });
   },
 
+  focusMessageInputField () {
+    let inputEl = this.$('#message-field').get(0);
+    inputEl.focus();
+  },
+
   actions: {
 
     processMessageOrCommand() {
@@ -69,13 +74,10 @@ export default Component.extend({
 
     addUsernameMentionToMessage (username) {
       const msg = this.newMessage;
-
       if (! msg.match(new RegExp(`^${username}`))) {
         this.set('newMessage', `${username}: ${msg}`)
       }
-
-      let inputEl = this.$('#message-field').get(0);
-      inputEl.focus();
+      this.focusMessageInputField();
     }
 
   }

--- a/app/components/channel-container/template.hbs
+++ b/app/components/channel-container/template.hbs
@@ -17,7 +17,8 @@
     <ul>
       {{#each channel.sortedMessages as |message|}}
         <li>
-          {{component message.type message=message}}
+          {{component message.type message=message
+                      onUsernameClick=(action "addUsernameMentionToMessage")}}
         </li>
       {{else}}
         {{#if channel.isLogged}}

--- a/app/components/message-chat/component.js
+++ b/app/components/message-chat/component.js
@@ -50,5 +50,13 @@ export default Component.extend({
              .replace(/\u000f/g,  '</span>');
 
     return htmlSafe(out);
-  })
+  }),
+
+  actions: {
+
+    usernameClick (username) {
+      this.onUsernameClick(username);
+    }
+
+  }
 });

--- a/app/components/message-chat/template.hbs
+++ b/app/components/message-chat/template.hbs
@@ -1,4 +1,6 @@
-<span class="chat-message__username" data-username={{message.nickname}}>
+<span class="chat-message__username"
+      data-username={{message.nickname}}
+      onclick={{action "usernameClick" message.nickname}}>
   {{message.nickname}}:
 </span>
 

--- a/tests/unit/components/channel-container-test.js
+++ b/tests/unit/components/channel-container-test.js
@@ -7,6 +7,7 @@ module('Unit | Component | channel-container', function(hooks) {
 
   test('add username mention to message, with empty message', function(assert) {
     let component = this.owner.factoryFor('component:channel-container').create();
+    component.focusMessageInputField = function () { return true; }
     assert.equal(component.newMessage, '');
 
     run(() => component.send('addUsernameMentionToMessage', 'toshi'));
@@ -16,6 +17,7 @@ module('Unit | Component | channel-container', function(hooks) {
 
   test('add username mention to message, with existing message', function(assert) {
     let component = this.owner.factoryFor('component:channel-container').create();
+    component.focusMessageInputField = function () { return true; }
     component.set('newMessage', 'hey, wasup?')
 
     run(() => component.send('addUsernameMentionToMessage', 'toshi'));
@@ -26,6 +28,7 @@ module('Unit | Component | channel-container', function(hooks) {
 
   test('add username mention to message, with existing message with username', function(assert) {
     let component = this.owner.factoryFor('component:channel-container').create();
+    component.focusMessageInputField = function () { return true; }
     component.set('newMessage', 'toshi: hey, wasup?')
 
     run(() => component.send('addUsernameMentionToMessage', 'toshi'));

--- a/tests/unit/components/channel-container-test.js
+++ b/tests/unit/components/channel-container-test.js
@@ -1,0 +1,36 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import { run } from '@ember/runloop';
+
+module('Unit | Component | channel-container', function(hooks) {
+  setupTest(hooks);
+
+  test('add username mention to message, with empty message', function(assert) {
+    let component = this.owner.factoryFor('component:channel-container').create();
+    assert.equal(component.newMessage, '');
+
+    run(() => component.send('addUsernameMentionToMessage', 'toshi'));
+
+    assert.equal(component.newMessage, 'toshi: ');
+  });
+
+  test('add username mention to message, with existing message', function(assert) {
+    let component = this.owner.factoryFor('component:channel-container').create();
+    component.set('newMessage', 'hey, wasup?')
+
+    run(() => component.send('addUsernameMentionToMessage', 'toshi'));
+
+    assert.equal(component.newMessage, 'toshi: hey, wasup?',
+                 'adds the name in front of the message');
+  });
+
+  test('add username mention to message, with existing message with username', function(assert) {
+    let component = this.owner.factoryFor('component:channel-container').create();
+    component.set('newMessage', 'toshi: hey, wasup?')
+
+    run(() => component.send('addUsernameMentionToMessage', 'toshi'));
+
+    assert.equal(component.newMessage, 'toshi: hey, wasup?',
+                 'does not add the name twice');
+  });
+});


### PR DESCRIPTION
This prefixes the new message in the message input field with a username, when the username of a channel message is clicked/tapped.

That makes it easy to reply to people, without having to type their username first. Especially useful on touch devices, but also nice on laptops.