### PR TITLE
Add partial message rendering

### DIFF
--- a/app/components/channel-container/component.js
+++ b/app/components/channel-container/component.js
@@ -16,7 +16,7 @@ export default Component.extend({
   newMessage: '',
   channel: null,
   automaticScrollingEnabled: true,
-  paginationObserver: null,
+  partialRenderingObserver: null,
   scrollingObserver: null,
 
   coms: service(),
@@ -26,7 +26,7 @@ export default Component.extend({
 
     scheduleOnce('afterRender', this, function () {
       this.createScrollingObserver();
-      this.createPaginationObserver();
+      this.createPartialRenderingObserver();
 
       // We need to define an empty handler for swipe events on the
       // #channel-content element, so that the actual handler of the app container
@@ -57,7 +57,7 @@ export default Component.extend({
   },
 
   // loads new messages when the last message comes into view
-  createPaginationObserver () {
+  createPartialRenderingObserver () {
     const config = {
       root: this.element,
       rootMargin: '0px',
@@ -67,13 +67,13 @@ export default Component.extend({
     let observer = new IntersectionObserver((entries, observer) => {
       entries.forEach(entry => {
         if (entry.isIntersecting) {
-          this.channel.increaseMessagePagination();
+          this.channel.increaseRenderedMessagesCount();
           observer.unobserve(entry.target);
         }
       });
     }, config);
 
-    this.set('paginationObserver', observer);
+    this.set('partialRenderingObserver', observer);
   },
 
   focusMessageInputField () {
@@ -93,7 +93,7 @@ export default Component.extend({
     let scrollingEnabled = this.automaticScrollingEnabled;
 
     if (isPresent(this.observedMessageElement)) {
-      this.paginationObserver.observe(this.observedMessageElement);
+      this.partialRenderingObserver.observe(this.observedMessageElement);
       this.set('observedMessageElement', null);
     }
 

--- a/app/components/channel-container/component.js
+++ b/app/components/channel-container/component.js
@@ -1,9 +1,8 @@
 /* global Hammer */
 import Component from '@ember/component';
-import { debounce, scheduleOnce } from '@ember/runloop';
+import { scheduleOnce } from '@ember/runloop';
 import { inject as service } from '@ember/service';
 import { task } from 'ember-concurrency';
-import { isPresent } from '@ember/utils';
 
 function scrollToBottom () {
   let elem = document.getElementById('channel-content');

--- a/app/components/channel-container/component.js
+++ b/app/components/channel-container/component.js
@@ -89,27 +89,6 @@ export default Component.extend({
     );
   }).drop(),
 
-  handleNewMessage () {
-    let scrollingEnabled = this.automaticScrollingEnabled;
-
-    if (isPresent(this.observedMessageElement)) {
-      this.partialRenderingObserver.observe(this.observedMessageElement);
-      this.set('observedMessageElement', null);
-    }
-
-    if (isPresent(this.latestMessageElement)) {
-      this.scrollingObserver.disconnect(); // unobserve all previous elements
-      this.scrollingObserver.observe(this.latestMessageElement);
-      this.set('latestMessageElement', null);
-    }
-
-    if (scrollingEnabled) {
-      scheduleOnce('afterRender', this, function () {
-        scrollToBottom();
-      });
-    }
-  },
-
   actions: {
 
     processMessageOrCommand () {
@@ -121,15 +100,22 @@ export default Component.extend({
     },
 
     addMessageElement (domElement, message) {
+      let scrollingEnabled = this.automaticScrollingEnabled;
+
       if (message.isObservingMessage) {
-        this.set('observedMessageElement', domElement);
+        this.partialRenderingObserver.observe(domElement);
       }
 
       if (message.isLatestMessage) {
-        this.set('latestMessageElement', domElement);
+        this.scrollingObserver.disconnect(); // unobserve all previous elements
+        this.scrollingObserver.observe(domElement);
       }
 
-      debounce(this, this.handleNewMessage, 50);
+      if (scrollingEnabled) {
+        scheduleOnce('afterRender', this, function () {
+          scrollToBottom();
+        });
+      }
     },
 
     menu(which, what) {

--- a/app/components/channel-container/component.js
+++ b/app/components/channel-container/component.js
@@ -39,7 +39,7 @@ export default Component.extend({
   createScrollingObserver () {
     const config = {
       root: this.element,
-      rootMargin: '0px',
+      rootMargin: `${this.element.clientHeight/4}px`, // TODO update the config when window is resized
       threshold: 1 // full element has to be in view
     };
 

--- a/app/components/channel-container/template.hbs
+++ b/app/components/channel-container/template.hbs
@@ -15,7 +15,7 @@
     {{/if}}
 
     <ul>
-      {{#each channel.paginatedMessages as |message|}}
+      {{#each channel.renderedMessages as |message|}}
         <li>
           {{component message.type message=message
                       onUsernameClick=(action "addUsernameMentionToMessage")

--- a/app/components/channel-container/template.hbs
+++ b/app/components/channel-container/template.hbs
@@ -15,10 +15,11 @@
     {{/if}}
 
     <ul>
-      {{#each channel.sortedMessages as |message|}}
+      {{#each channel.paginatedMessages as |message|}}
         <li>
           {{component message.type message=message
-                      onUsernameClick=(action "addUsernameMentionToMessage")}}
+                      onUsernameClick=(action "addUsernameMentionToMessage")
+                      onInsert=(action "addMessageElement")}}
         </li>
       {{else}}
         {{#if channel.isLogged}}

--- a/app/components/message-chat/component.js
+++ b/app/components/message-chat/component.js
@@ -52,6 +52,13 @@ export default Component.extend({
     return htmlSafe(out);
   }),
 
+  didInsertElement () {
+    this._super(...arguments);
+
+    let domElement = this.element;
+    this.onInsert(domElement, this.message);
+  },
+
   actions: {
 
     usernameClick (username) {

--- a/app/controllers/space/base_channel.js
+++ b/app/controllers/space/base_channel.js
@@ -9,6 +9,7 @@ export default Controller.extend({
   space: controller(),
   coms: service(),
   storage: service('remotestorage'),
+  automaticSrollingEnabled: true,
 
   createMessage(message, type) {
     return Message.create({

--- a/app/models/base_channel.js
+++ b/app/models/base_channel.js
@@ -18,7 +18,6 @@ export default EmberObject.extend({
 
   renderedMessagesCount: 0, // maximum number of messages to render
   renderedMessagesAddendumAmount: 30, // number of messages to increase rendering count by
-  observedMessageOffset: 20, // position of message that triggers the increase of rendering count
 
   init() {
     this._super(...arguments);
@@ -60,9 +59,7 @@ export default EmberObject.extend({
   renderedMessages: computed('sortedMessages.[]', 'renderedMessagesCount', function () {
     let messages = this.sortedMessages.slice(-this.renderedMessagesCount);
     if (isPresent(messages)) {
-      let messagePosition = messages.length > this.observedMessageOffset ? this.observedMessageOffset : 0;
-      messages[messagePosition].set('isObservingMessage', true);
-
+      messages.firstObject.set('isObservingMessage', true);
       messages.lastObject.set('isLatestMessage', true);
     }
 

--- a/app/models/base_channel.js
+++ b/app/models/base_channel.js
@@ -16,6 +16,9 @@ export default EmberObject.extend({
   unreadMentions: false,
   visible: false, // Current/active channel
 
+  paginationMessagesPerPage: 30,
+  paginationMessagesToLoad: 0,
+
   init() {
     this._super(...arguments);
 
@@ -46,6 +49,20 @@ export default EmberObject.extend({
 
   sortedMessages: computed('messages.@each.date', function() {
     return this.messages.sortBy('date');
+  }),
+
+  increaseMessagePagination () {
+    let newMessageCount = this.paginatedMessages.length + this.paginationMessagesPerPage;
+    this.set('paginationMessagesToLoad', newMessageCount);
+  },
+
+  paginatedMessages: computed('sortedMessages', 'paginationMessagesToLoad', function () {
+    let messages = this.sortedMessages.slice(-this.paginationMessagesToLoad);
+    if (isPresent(messages)) {
+      messages.firstObject.set('isObservingMessage', true);
+    }
+
+    return messages;
   }),
 
   sortedUserList: computed('userList.[]', function () {

--- a/app/models/base_channel.js
+++ b/app/models/base_channel.js
@@ -16,9 +16,9 @@ export default EmberObject.extend({
   unreadMentions: false,
   visible: false, // Current/active channel
 
-  paginationMessagesPerPage: 30,
-  paginationMessagesToLoad: 0,
-  paginationOffset: 20,
+  renderedMessagesCount: 0, // maximum number of messages to render
+  renderedMessagesAddendumAmount: 30, // number of messages to increase rendering count by
+  observedMessageOffset: 20, // position of message that triggers the increase of rendering count
 
   init() {
     this._super(...arguments);
@@ -52,15 +52,15 @@ export default EmberObject.extend({
     return this.messages.sortBy('date');
   }),
 
-  increaseMessagePagination () {
-    let newMessageCount = this.paginatedMessages.length + this.paginationMessagesPerPage;
-    this.set('paginationMessagesToLoad', newMessageCount);
+  increaseRenderedMessagesCount () {
+    let newMessageCount = this.renderedMessages.length + this.renderedMessagesAddendumAmount;
+    this.set('renderedMessagesCount', newMessageCount);
   },
 
-  paginatedMessages: computed('sortedMessages', 'paginationMessagesToLoad', function () {
-    let messages = this.sortedMessages.slice(-this.paginationMessagesToLoad);
+  renderedMessages: computed('sortedMessages', 'renderedMessagesCount', function () {
+    let messages = this.sortedMessages.slice(-this.renderedMessagesCount);
     if (isPresent(messages)) {
-      let messagePosition = messages.length > this.paginationOffset ? this.paginationOffset : 0;
+      let messagePosition = messages.length > this.observedMessageOffset ? this.observedMessageOffset : 0;
       messages[messagePosition].set('isObservingMessage', true);
 
       messages.lastObject.set('isLatestMessage', true);

--- a/app/models/base_channel.js
+++ b/app/models/base_channel.js
@@ -57,7 +57,7 @@ export default EmberObject.extend({
     this.set('renderedMessagesCount', newMessageCount);
   },
 
-  renderedMessages: computed('sortedMessages', 'renderedMessagesCount', function () {
+  renderedMessages: computed('sortedMessages.[]', 'renderedMessagesCount', function () {
     let messages = this.sortedMessages.slice(-this.renderedMessagesCount);
     if (isPresent(messages)) {
       let messagePosition = messages.length > this.observedMessageOffset ? this.observedMessageOffset : 0;

--- a/app/models/base_channel.js
+++ b/app/models/base_channel.js
@@ -18,6 +18,7 @@ export default EmberObject.extend({
 
   paginationMessagesPerPage: 30,
   paginationMessagesToLoad: 0,
+  paginationOffset: 20,
 
   init() {
     this._super(...arguments);
@@ -59,7 +60,8 @@ export default EmberObject.extend({
   paginatedMessages: computed('sortedMessages', 'paginationMessagesToLoad', function () {
     let messages = this.sortedMessages.slice(-this.paginationMessagesToLoad);
     if (isPresent(messages)) {
-      messages.firstObject.set('isObservingMessage', true);
+      let messagePosition = messages.length > this.paginationOffset ? this.paginationOffset : 0;
+      messages[messagePosition].set('isObservingMessage', true);
 
       messages.lastObject.set('isLatestMessage', true);
     }

--- a/app/models/base_channel.js
+++ b/app/models/base_channel.js
@@ -60,6 +60,8 @@ export default EmberObject.extend({
     let messages = this.sortedMessages.slice(-this.paginationMessagesToLoad);
     if (isPresent(messages)) {
       messages.firstObject.set('isObservingMessage', true);
+
+      messages.lastObject.set('isLatestMessage', true);
     }
 
     return messages;

--- a/app/routes/space/base_channel.js
+++ b/app/routes/space/base_channel.js
@@ -30,6 +30,9 @@ export default Route.extend({
   setupController(controller, model) {
     this._super(controller, model);
 
+    model.set('paginationMessagesToLoad', model.paginationMessagesPerPage);
+    controller.set('automaticScrollingEnabled', true);
+
     scheduleOnce('afterRender', function() {
       focusMessageInput();
     });

--- a/app/routes/space/base_channel.js
+++ b/app/routes/space/base_channel.js
@@ -30,7 +30,7 @@ export default Route.extend({
   setupController(controller, model) {
     this._super(controller, model);
 
-    model.set('paginationMessagesToLoad', model.paginationMessagesPerPage);
+    model.set('renderedMessagesCount', model.renderedMessagesAddendumAmount);
     controller.set('automaticScrollingEnabled', true);
 
     scheduleOnce('afterRender', function() {

--- a/app/templates/space/channel.hbs
+++ b/app/templates/space/channel.hbs
@@ -1,5 +1,6 @@
 {{channel-container channel=model
                     newMessage=newMessage
+                    automaticScrollingEnabled=automaticScrollingEnabled
                     onMessage=(action "sendMessage")
                     onCommand=(action "executeCommand")
                     menu=(route-action "menu")}}


### PR DESCRIPTION
Closes #92

This displays only the last 30 messages when opening a channel to improve the rendering speed. More messages are then displayed when scrolling up to the top of the page.

When the user starts scrolling, automatic scrolling to the bottom on new messages is disabled. It's re-enabled when the user scrolls to the bottom again or when switching channels.