### PR TITLE
Use new URL for activity-streams lib

### DIFF
--- a/vendor/sh-assets-remote.html
+++ b/vendor/sh-assets-remote.html
@@ -1,3 +1,3 @@
-<script src="https://sockethub.kosmos.org:10550/activity-streams.js"></script>
+<script src="https://sockethub.kosmos.org:10550/activity-streams.min.js"></script>
 <script src="https://sockethub.kosmos.org:10550/socket.io.js"></script>
 <script src="https://sockethub.kosmos.org:10550/sockethub-client.js"></script>


### PR DESCRIPTION
Refs #161

Newer versions of SocketHub don't provide an unminified version of activity-streams.js anymore.

So until sockethub/sockethub#237 is fixed, we use the minified version.