### PR TITLE
Use partial rendering for large user lists

### DIFF
--- a/app/components/channel-container/template.hbs
+++ b/app/components/channel-container/template.hbs
@@ -49,11 +49,6 @@
       {{#link-to "index" class="active"}}<i class="icon-users"></i>{{/link-to}}<a href="#"><i class="icon-paperclip"></i></a>{{#link-to "settings"}}<i class="icon-cog"></i>{{/link-to}}<a href="#"><i class="icon-resize-enlarge"></i></a>
     </nav>
   </header>
-  <section id="user-list" class="main">
-    <ul>
-      {{#each channel.sortedUserList as |username|}}
-        <li>{{link-to-username username=username}}</li>
-      {{/each}}
-    </ul>
-  </section>
+
+  {{user-list users=channel.sortedUserList}}
 </aside>

--- a/app/components/scrolling-observer/component.js
+++ b/app/components/scrolling-observer/component.js
@@ -1,0 +1,57 @@
+import Component from '@ember/component';
+import { scheduleOnce } from '@ember/runloop';
+import { observer } from '@ember/object';
+
+export default Component.extend({
+
+  rootElement: null,
+  rootMargin: '100px',
+  threshold: 0,
+  enabled: true,
+  observer: null,
+
+  didInsertElement () {
+    this._super(...arguments);
+
+    scheduleOnce('afterRender', this, function () {
+      this.createIntersectionObserver();
+    });
+  },
+
+  createIntersectionObserver () {
+    const config = {
+      root: this.rootElement,
+      rootMargin: this.rootMargin,
+      threshold: this.threshold
+    };
+
+    let observer = new IntersectionObserver((entries, observer) => {
+      entries.forEach(entry => {
+        if (entry.isIntersecting) {
+          if (this.onIntersect) {
+            this.onIntersect();
+          }
+          if (this.enabled) {
+            scheduleOnce('afterRender', this, function () {
+              observer.unobserve(entry.target);
+              observer.observe(entry.target);
+            });
+          }
+        }
+      });
+    }, config);
+
+    observer.observe(this.element);
+
+    this.set('observer', observer);
+  },
+
+  enabledChanged: observer('enabled', function () {
+    if (this.enabled) {
+      this.observer.observe(this.element);
+    } else {
+      this.observer.disconnect();
+    }
+  })
+
+});

--- a/app/components/user-list/component.js
+++ b/app/components/user-list/component.js
@@ -1,0 +1,41 @@
+import Component from '@ember/component';
+import { computed, observer } from '@ember/object';
+import { scheduleOnce } from '@ember/runloop';
+
+export default Component.extend({
+
+  tagName: 'section',
+  elementId: 'user-list',
+  classNames: ['main'],
+  users: null,
+
+  renderedUsersCount: 0,
+  renderedUsersAddendumAmount: 50, // number of users to add when scrolling to bottom
+  partialRenderingEnabled: true,
+
+  renderedUsers: computed('users.[]', 'renderedUsersCount', function () {
+    if (this.partialRenderingEnabled) {
+      return this.users.slice(0, this.renderedUsersCount);
+    } else {
+      return this.users;
+    }
+  }),
+
+  // called when changing list of users (i.e. when switching channels)
+  usersChanged: observer('users', function () {
+    this.set('renderedUsersCount', this.renderedUsersAddendumAmount);
+    this.set('partialRenderingEnabled', true);
+    scheduleOnce('afterRender', this, function () {
+      this.element.scrollTop = 0;
+    });
+  }),
+
+  actions: {
+    increaseRenderedUsersCount () {
+      let newUsersCount = this.renderedUsersCount + this.renderedUsersAddendumAmount;
+      this.set('renderedUsersCount', newUsersCount);
+      this.set('partialRenderingEnabled', newUsersCount < this.users.length);
+    }
+  }
+
+});

--- a/app/components/user-list/template.hbs
+++ b/app/components/user-list/template.hbs
@@ -1,0 +1,10 @@
+<ul>
+  {{#each renderedUsers as |username|}}
+    <li>{{link-to-username username=username}}</li>
+  {{/each}}
+  <li class="last-element"></li>
+  {{scrolling-observer rootElement=element
+                       rootMargin="200px"
+                       enabled=partialRenderingEnabled
+                       onIntersect=(action "increaseRenderedUsersCount")}}
+</ul>


### PR DESCRIPTION
Closes #163

To improve the performance when switching to channels with a lot of users, only a subset of the users is rendered at first. More users will be rendered, when scrolling to the bottom of the list.