### PR TITLE
Partial message rendering

### DIFF
--- a/app/components/channel-container/template.hbs
+++ b/app/components/channel-container/template.hbs
@@ -15,7 +15,13 @@
     {{/if}}
 
     <ul>
-      {{#each channel.sortedMessages as |message|}}
+      <li>
+        {{scrolling-observer rootElement="#channel-content"
+                             rootMargin=partialRenderingObserverMargin
+                             enabled=partialRenderingEnabled
+                             onIntersect=(action "increaseRenderedMessagesCount")}}
+      </li>
+      {{#each renderedMessages as |message|}}
         <li>
           {{component message.type message=message
                       onUsernameClick=(action "addUsernameMentionToMessage")}}
@@ -27,6 +33,14 @@
           <li class="no-messages discreet">No Kosmos logs configured for this channel. <a href="https://wiki.kosmos.org/Setting_up_channel_logs" target="_blank" rel="noopener">Learn more</a></li>
         {{/if}}
       {{/each}}
+      <li>
+        {{scrolling-observer rootElement=element
+                             rootMargin="0px"
+                             threshold=1
+                             retriggeringEnabled=false
+                             onIntersect=(action "setAutomaticScrolling" true)
+                             onDiverge=(action "setAutomaticScrolling" false)}}
+      </li>
     </ul>
   </section>
 


### PR DESCRIPTION
Closes #92

This displays only the last 30 messages when opening a channel to improve the rendering speed. More messages are then displayed when scrolling up to the top of the page.

This PR is a replacement for #162 and should fix all the remaining problems that PR still had.

The code is also much cleaner/simpler. It uses the scrolling-observer component introduced in #166 both for rendering more messages when scrolling up, as well as enabling/disabling automatic scrolling when scrolling down.