### PR TITLE
Show own messages in different windows.

### DIFF
--- a/app/controllers/space/base_channel.js
+++ b/app/controllers/space/base_channel.js
@@ -29,7 +29,7 @@ export default Controller.extend({
         message.get('content')
       );
 
-      this.get('model.messages').pushObject(message);
+      this.get('model').addMessage(message);
       this.set('newMessage', null);
     },
 
@@ -93,7 +93,7 @@ export default Controller.extend({
         message.get('content')
       );
 
-      this.get('model.messages').pushObject(message);
+      this.get('model').addMessage(message);
     },
 
     msgCommand: function(args) {

--- a/app/services/sockethub-irc.js
+++ b/app/services/sockethub-irc.js
@@ -156,10 +156,7 @@ export default Service.extend({
     const channel = this.getChannelForMessage(space, message);
     const channelMessage = channelMessageFromSockethubObject(message);
 
-    // TODO should check for message and update sent status if exists
-    if (channelMessage.get('nickname') !== space.get('userNickname')) {
-      channel.addMessage(channelMessage);
-    }
+    channel.addMessage(channelMessage);
   },
 
   /**

--- a/app/utils/channel-message-from-sockethub-object.js
+++ b/app/utils/channel-message-from-sockethub-object.js
@@ -3,7 +3,7 @@ import Message from 'hyperchannel/models/message';
 export default function channelMessageFromSockethubObject(message) {
   let channelMessage = Message.create({
     type: message.object['@type'] === 'me' ? 'message-chat-me' : 'message-chat',
-    date: new Date(message.published),
+    date: message.published ? new Date(message.published) : new Date(),
     nickname: message.actor.displayName || message.actor['@id'],
     content: message.object.content
   });


### PR DESCRIPTION
Closes #117

This change makes sure that your own messages are also shown when having the app open in another tab, window or browser.

It also fixes a bug of a missing date headline when writing the first message of the day in a channel