### PR TITLE
Disconnect IntersectionObserver when destroying component

### DIFF
--- a/app/components/scrolling-observer/component.js
+++ b/app/components/scrolling-observer/component.js
@@ -19,6 +19,14 @@ export default Component.extend({
     });
   },
 
+  willDestroyElement () {
+    this._super(...arguments);
+
+    if (this.observer) {
+      this.observer.disconnect();
+    }
+  },
+
   createIntersectionObserver () {
     let rootElement = this.rootElement;
     if (typeof rootElement === 'string') {


### PR DESCRIPTION
This fixes an exception "Trying to call set on a destroyed object" when switching between a user channel and a group chat channel.