### PR TITLE
Update ember-route-action-helper

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9495,9 +9495,9 @@
       "dev": true
     },
     "ember-route-action-helper": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/ember-route-action-helper/-/ember-route-action-helper-2.0.6.tgz",
-      "integrity": "sha1-HVBFQ1DXESvjJqtEBY8GzykdX9k=",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/ember-route-action-helper/-/ember-route-action-helper-2.0.7.tgz",
+      "integrity": "sha512-8GEnB9hfPdh5U19ubmojVZQBu6aUIfQuiv6xnsdss7V3TMspjI1Ak8lqoqEzww8Dv+sxv8YWma0IhKPFxrVJag==",
       "dev": true,
       "requires": {
         "ember-cli-babel": "^6.8.1",
@@ -9519,9 +9519,9 @@
           }
         },
         "broccoli-funnel": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.1.tgz",
-          "integrity": "sha512-C8Lnp9TVsSSiZMGEF16C0dCiNg2oJqUKwuZ1K4kVC6qRPG/2Cj/rtB5kRCC9qEbwqhX71bDbfHROx0L3J7zXQg==",
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz",
+          "integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
           "dev": true,
           "requires": {
             "array-equal": "^1.0.0",
@@ -9558,44 +9558,23 @@
             "clone": "^2.0.0",
             "ember-cli-version-checker": "^2.1.2",
             "semver": "^5.5.0"
-          },
-          "dependencies": {
-            "semver": {
-              "version": "5.6.0",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-              "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
-              "dev": true
-            }
           }
         },
         "ember-cli-version-checker": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.1.2.tgz",
-          "integrity": "sha512-sjkHGr4IGXnO3EUcY21380Xo9Qf6bC8HWH4D62bVnrQop/8uha5XgMQRoAflMCeH6suMrezQL287JUoYc2smEw==",
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz",
+          "integrity": "sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==",
           "dev": true,
           "requires": {
             "resolve": "^1.3.3",
             "semver": "^5.3.0"
           }
         },
-        "ember-factory-for-polyfill": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/ember-factory-for-polyfill/-/ember-factory-for-polyfill-1.3.1.tgz",
-          "integrity": "sha512-y3iG2iCzH96lZMTWQw6LWNLAfOmDC4pXKbZP6FxG8lt7GGaNFkZjwsf+Z5GAe7kxfD7UG4lVkF7x37K82rySGA==",
-          "dev": true,
-          "requires": {
-            "ember-cli-version-checker": "^2.1.0"
-          }
-        },
-        "ember-getowner-polyfill": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/ember-getowner-polyfill/-/ember-getowner-polyfill-2.2.0.tgz",
-          "integrity": "sha512-rwGMJgbGzxIAiWYjdpAh04Abvt0s3HuS/VjHzUFhVyVg2pzAuz45B9AzOxYXzkp88vFC7FPaiA4kE8NxNk4A4Q==",
-          "dev": true,
-          "requires": {
-            "ember-cli-version-checker": "^2.1.0",
-            "ember-factory-for-polyfill": "^1.3.1"
-          }
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "ember-moment": "^7.8.0",
     "ember-qunit": "^3.4.1",
     "ember-resolver": "^5.0.1",
-    "ember-route-action-helper": "^2.0.6",
+    "ember-route-action-helper": "^2.0.7",
     "ember-service-worker": "^0.7.2",
     "ember-service-worker-hubot-web-push-notifications": "67P/ember-service-worker-hubot-web-push-notifications",
     "ember-sinon": "^3.1.0",


### PR DESCRIPTION
This fixes a deprecation warning about using a private API.