### PR TITLE
Don't send emails for successful Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,11 @@ language: node_js
 node_js:
   - "lts/*"
 
+notifications:
+  email:
+    on_success: never
+    on_failure: always
+
 sudo: required
 
 services:


### PR DESCRIPTION
Getting emails from Travis everytime you push is pretty annoying.

This deactivates email notifications for successful builds, so you only get notified when a build fails.