### PR TITLE
Add username completion

### DIFF
--- a/app/components/channel-container/template.hbs
+++ b/app/components/channel-container/template.hbs
@@ -45,15 +45,9 @@
   </section>
 
   <footer>
-    <section id="new-message">
-      <form {{action "processMessageOrCommand" on="submit"}}>
-        {{channel-input-field value=newMessage
-                              placeholder="Type a message and hit enter"
-                              name="chat-message"
-                              id="message-field"
-                              autocomplete="off"}}
-      </form>
-    </section>
+    {{message-input message=newMessage
+                    onSend=(action "processMessageOrCommand")
+                    usernames=channel.userList}}
   </footer>
 </main>
 

--- a/app/components/message-input/component.js
+++ b/app/components/message-input/component.js
@@ -1,0 +1,68 @@
+import Component from '@ember/component';
+import { bindKeyboardShortcuts, unbindKeyboardShortcuts } from 'ember-keyboard-shortcuts';
+import { isPresent } from '@ember/utils';
+import { scheduleOnce } from '@ember/runloop';
+
+export default Component.extend({
+
+  tagName: 'section',
+  elementId: 'new-message',
+
+  message: '',
+  usernames: null,
+
+  keyboardShortcuts: Object.freeze({
+    'tab': 'completeUsername'
+  }),
+
+  didInsertElement () {
+    this._super(...arguments);
+    bindKeyboardShortcuts(this);
+  },
+
+  willDestroyElement () {
+    this._super(...arguments);
+    unbindKeyboardShortcuts(this);
+  },
+
+  actions: {
+
+    completeUsername () {
+      let input = this.element.querySelector('#message-field');
+      let cursorPosition = input.selectionStart;
+      let textBeforeCursor = this.message.slice(0, cursorPosition);
+      let textAfterCursor = this.message.slice(cursorPosition);
+      let words = textBeforeCursor.split(' ');
+      let searchWord = words.pop();
+
+      if (isPresent(searchWord)) {
+        let username = this.usernames.find(username => {
+          return username.toLowerCase().startsWith(searchWord.toLowerCase());
+        });
+
+        if (isPresent(username)) {
+          // add a colon when inserting the username in the beginning
+          if (words.length === 0) {
+            username = `${username}: `;
+          }
+
+          let lengthDiff = username.length - searchWord.length;
+          let newCursorPosition = cursorPosition + lengthDiff;
+
+          words.push(username);
+          let newMessage = `${words.join(' ')}${textAfterCursor}`;
+          this.set('message', newMessage);
+
+          // set the cursor right behind the inserted username,
+          // but we have to wait for the update of the input first
+          scheduleOnce('afterRender', this, function () {
+            input.focus();
+            input.setSelectionRange(newCursorPosition, newCursorPosition);
+          });
+        }
+      }
+    }
+
+  }
+
+});

--- a/app/components/message-input/component.js
+++ b/app/components/message-input/component.js
@@ -1,6 +1,6 @@
 import Component from '@ember/component';
 import { bindKeyboardShortcuts, unbindKeyboardShortcuts } from 'ember-keyboard-shortcuts';
-import { isPresent } from '@ember/utils';
+import { isEmpty } from '@ember/utils';
 import { scheduleOnce } from '@ember/runloop';
 
 export default Component.extend({

--- a/app/components/message-input/component.js
+++ b/app/components/message-input/component.js
@@ -28,39 +28,39 @@ export default Component.extend({
   actions: {
 
     completeUsername () {
-      let input = this.element.querySelector('#message-field');
-      let cursorPosition = input.selectionStart;
-      let textBeforeCursor = this.message.slice(0, cursorPosition);
-      let textAfterCursor = this.message.slice(cursorPosition);
-      let words = textBeforeCursor.split(' ');
-      let searchWord = words.pop();
+      const input = this.element.querySelector('#message-field');
+      const cursorPosition = input.selectionStart;
+      const textBeforeCursor = this.message.slice(0, cursorPosition);
+      const textAfterCursor = this.message.slice(cursorPosition);
+      const words = textBeforeCursor.split(' ');
+      const searchWord = words.pop();
 
-      if (isPresent(searchWord)) {
-        let username = this.usernames.find(username => {
-          return username.toLowerCase().startsWith(searchWord.toLowerCase());
-        });
+      if (isEmpty(searchWord)) return;
 
-        if (isPresent(username)) {
-          // add a colon when inserting the username in the beginning
-          if (words.length === 0) {
-            username = `${username}: `;
-          }
+      let username = this.usernames.find(username => {
+        return username.toLowerCase().startsWith(searchWord.toLowerCase());
+      });
 
-          let lengthDiff = username.length - searchWord.length;
-          let newCursorPosition = cursorPosition + lengthDiff;
+      if (isEmpty(username)) return;
 
-          words.push(username);
-          let newMessage = `${words.join(' ')}${textAfterCursor}`;
-          this.set('message', newMessage);
-
-          // set the cursor right behind the inserted username,
-          // but we have to wait for the update of the input first
-          scheduleOnce('afterRender', this, function () {
-            input.focus();
-            input.setSelectionRange(newCursorPosition, newCursorPosition);
-          });
-        }
+      // add a colon when inserting the username in the beginning
+      if (words.length === 0) {
+        username = `${username}: `;
       }
+
+      const lengthDiff = username.length - searchWord.length;
+      const newCursorPosition = cursorPosition + lengthDiff;
+
+      words.push(username);
+      const newMessage = `${words.join(' ')}${textAfterCursor}`;
+      this.set('message', newMessage);
+
+      // set the cursor right behind the inserted username,
+      // but we have to wait for the update of the input first
+      scheduleOnce('afterRender', this, function () {
+        input.focus();
+        input.setSelectionRange(newCursorPosition, newCursorPosition);
+      });
     }
 
   }

--- a/app/components/message-input/template.hbs
+++ b/app/components/message-input/template.hbs
@@ -1,0 +1,7 @@
+<form {{action onSend on="submit"}}>
+  {{channel-input-field value=message
+                        placeholder="Type a message and hit enter"
+                        name="chat-message"
+                        id="message-field"
+                        autocomplete="off"}}
+</form>


### PR DESCRIPTION
Closes #26

Just write the first letter(s) of a username and hit tab.

When the name is completed at the beginning, a colon is added after the name.

This doesn't support cycling through names when there are multiple users with the same prefix yet. I'll create a separate issue for it.