### PR TITLE
Refactor layout

### DIFF
--- a/app/components/channel-container/template.hbs
+++ b/app/components/channel-container/template.hbs
@@ -1,62 +1,66 @@
 <main>
-  <header id="channel-header" {{action "menu" "global" "toggle"}}>
-    <h2 id="channel-name" class={{if channel.connected "connected" "disconnected"}}>{{channel.name}}</h2>
-    <p id="channel-title">{{channel.formattedTopic}}</p>
+  <header id="channel-header">
+    <h2 id="channel-name"
+        class={{if channel.connected "connected" "disconnected"}}
+        {{action "menu" "global" "toggle"}}>
+      {{channel.name}}
+    </h2>
+    <p id="channel-title">
+      {{channel.formattedTopic}}
+    </p>
     <nav>
-      <a {{action "leaveChannel" space channel}} title="Leave {{channel.name}}"><IconLogOut /></a>
+      {{#link-to "index" class="active"}}<IconUsers />{{/link-to}}<a><IconPaperclip /></a><a><IconSettings /></a><a {{action "leaveChannel" space channel}} title="Leave {{channel.name}}"><IconLogOut /></a>
     </nav>
   </header>
 
-  <section id="channel-content" class="main">
-    {{#if channel.isLogged}}
-      <a onclick={{perform loadPreviousMessages}} class="load-previous" role="button">
-        Load previous messages
-      </a>
-    {{/if}}
-
-    <ul>
-      <li>
-        {{scrolling-observer rootElement="#channel-content"
-                             rootMargin=partialRenderingObserverMargin
-                             enabled=partialRenderingEnabled
-                             onIntersect=(action "increaseRenderedMessagesCount")}}
-      </li>
-      {{#each renderedMessages as |message|}}
-        <li>
-          {{component message.type message=message
-                      onUsernameClick=(action "addUsernameMentionToMessage")}}
-        </li>
-      {{else}}
+  <div class="content-container">
+    <div class="content">
+      <section id="channel-content" class="main">
         {{#if channel.isLogged}}
-          <li class="no-messages discreet">No recent messages to display.</li>
-        {{else}}
-          <li class="no-messages discreet">No Kosmos logs configured for this channel. <a href="https://wiki.kosmos.org/Setting_up_channel_logs" target="_blank" rel="noopener">Learn more</a></li>
+          <a onclick={{perform loadPreviousMessages}} class="load-previous" role="button">
+            Load previous messages
+          </a>
         {{/if}}
-      {{/each}}
-      <li>
-        {{scrolling-observer rootElement=element
-                             rootMargin="0px"
-                             threshold=1
-                             retriggeringEnabled=false
-                             onIntersect=(action "setAutomaticScrolling" true)
-                             onDiverge=(action "setAutomaticScrolling" false)}}
-      </li>
-    </ul>
-  </section>
 
-  <footer>
-    {{message-input message=newMessage
-                    onSend=(action "processMessageOrCommand")
-                    usernames=channel.userList}}
-  </footer>
+        <ul>
+          <li>
+            {{scrolling-observer rootElement="#channel-content"
+                                 rootMargin=partialRenderingObserverMargin
+                                 enabled=partialRenderingEnabled
+                                 onIntersect=(action "increaseRenderedMessagesCount")}}
+          </li>
+          {{#each renderedMessages as |message|}}
+            <li>
+              {{component message.type message=message
+                          onUsernameClick=(action "addUsernameMentionToMessage")}}
+            </li>
+          {{else}}
+            {{#if channel.isLogged}}
+              <li class="no-messages discreet">No recent messages to display.</li>
+            {{else}}
+              <li class="no-messages discreet">No Kosmos logs configured for this channel. <a href="https://wiki.kosmos.org/Setting_up_channel_logs" target="_blank" rel="noopener">Learn more</a></li>
+            {{/if}}
+          {{/each}}
+          <li>
+            {{scrolling-observer rootElement=element
+                                 rootMargin="0px"
+                                 threshold=1
+                                 retriggeringEnabled=false
+                                 onIntersect=(action "setAutomaticScrolling" true)
+                                 onDiverge=(action "setAutomaticScrolling" false)}}
+          </li>
+        </ul>
+      </section>
+
+      <footer>
+        {{message-input message=newMessage
+                        onSend=(action "processMessageOrCommand")
+                        usernames=channel.userList}}
+      </footer>
+    </div>
+
+    <aside>
+      {{user-list users=channel.sortedUserList}}
+    </aside>
+  </div>
 </main>
-
-<aside>
-  <header>
-    <nav>
-      {{#link-to "index" class="active"}}<IconUsers />{{/link-to}}<a href="#"><IconAtSign /></a><a href="#"><IconPaperclip /></a><a href="#"><IconInfo /></a>
-    </nav>
-  </header>
-
-  {{user-list users=channel.sortedUserList}}
-</aside>

--- a/app/components/link-to-username/component.js
+++ b/app/components/link-to-username/component.js
@@ -1,6 +1,6 @@
 import Component from '@ember/component';
 import { computed } from '@ember/object';
-import { isPresent } from '@ember/utils';
+import { isPresent, isEmpty } from '@ember/utils';
 
 export default Component.extend({
 
@@ -18,18 +18,16 @@ export default Component.extend({
   },
 
   role: computed('username', 'roles', function() {
+    if (isEmpty(this.username)) return 'normal';
+
     const role = this.roles[this.username[0]];
-
-    if (isPresent(role)) {
-      return role;
-    }
-
-    return 'normal';
+    return isPresent(role) ? role : 'normal';
   }),
 
   usernameWithoutPrefix: computed('username', 'roles', function() {
-    const regex = RegExp(`^[\\${Object.keys(this.roles).join('\\')}]`);
+    if (isEmpty(this.username)) return null;
 
+    const regex = RegExp(`^[\\${Object.keys(this.roles).join('\\')}]`);
     return this.username.replace(regex, '');
   })
 

--- a/app/styles/_colors.scss
+++ b/app/styles/_colors.scss
@@ -1,0 +1,7 @@
+$color-cyan: #00ffff;
+$color-magenta: #ff00ff;
+$color-yellow: #ffff00;
+
+$background-color-cyan: rgba($color-cyan, 0.2);
+$background-color-magenta: rgba($color-magenta, 0.2);
+$background-color-yellow: rgba($color-yellow, 0.2);

--- a/app/styles/_layout.scss
+++ b/app/styles/_layout.scss
@@ -98,11 +98,21 @@ div#channel {
     flex: 1;
     overflow: auto;
 
-    header {
-      nav {
-        position: absolute;
-        top: 0;
-        right: 0;
+    .content-container {
+      flex: 1;
+      display: flex;
+      align-items: stretch;
+      flex-direction: row;
+      justify-content: flex-start;
+      overflow: hidden;
+
+      > .content {
+        flex: 1;
+        @include app-column;
+      }
+
+      > aside {
+        flex: 0 0 $sidebarWidth;
       }
     }
   }
@@ -126,21 +136,6 @@ section#settings, section#space {
   div#channel {
     transform: translate3d(168px, 0, 0);
     transition: transform 0.4s;
-  }
-}
-
-@media screen and (max-width: 900px) {
-  div#channel {
-    main {
-      header {
-        p#channel-title {
-          display: none;
-        }
-      }
-    }
-    aside {
-      display: none;
-    }
   }
 }
 

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -1,8 +1,11 @@
 @import "bourbon";
+@import "colors";
+@import "vendor/include_media";
 
 $modular-scale-ratio: $golden;
 $headerHeight: 42px;
 $sidebarWidth: 168px;
+$breakpoints: (desktop: 900px);
 
 * {
   margin: 0;
@@ -50,7 +53,7 @@ input, button {
 
 header {
   &#sitename {
-    background-color: rgba(255,255,0,0.2);
+    background-color: $background-color-yellow;
   }
 
   a {
@@ -70,25 +73,6 @@ header {
 
 #channel {
   main {
-    header {
-      padding: 0 1em;
-      background-color: rgba(255,0,255,0.2);
-      h2#channel-name {
-        display: inline;
-        height: $headerHeight;
-        line-height: $headerHeight;
-        margin-right: 1em;
-        &.disconnected {
-          opacity: 0.5;
-          transition: opacity 0.2s linear;
-        }
-      }
-      p#channel-title {
-        display: inline;
-        font-style: italic;
-      }
-    }
-
     footer {
       background-color: #efefef;
       color: #333;
@@ -97,6 +81,7 @@ header {
         padding: 0 14px;
         color: #fff;
         border-radius: 3px;
+
         input[name=chat-message] {
           width: 100%;
           background: none;
@@ -109,22 +94,6 @@ header {
   }
 
   aside {
-    header {
-      nav {
-        a {
-          background-color: rgba(255,255,0,0.2);
-
-          &.active {
-            background-color: rgba(0,255,255,0.2);
-          }
-
-          &:hover {
-            background-color: rgba(255,255,255,0.3);
-          }
-        }
-      }
-    }
-
     section#user-list {
       // TODO unify with other sidebar nav
       background-color: rgba(0,255,255,0.2);
@@ -132,6 +101,7 @@ header {
 
       > ul {
         list-style: none;
+
         li {
           a {
             display: block;

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -28,10 +28,8 @@ body {
   color: #fff;
   background-image: url('/img/bg.jpg');
   background-repeat: none;
-}
 
-@media screen and (min-width: 900px) {
-  body {
+  @include media(">desktop") {
     background-size: cover;
   }
 }
@@ -63,58 +61,11 @@ header {
 
 #global {
   .main {
-    background-color: rgba(0,255,255,0.2);
+    background-color: $background-color-cyan;
   }
 
   footer {
-    background-color: rgba(0,255,255,0.2);
-  }
-}
-
-#channel {
-  main {
-    footer {
-      background-color: #efefef;
-      color: #333;
-
-      section#new-message {
-        padding: 0 14px;
-        color: #fff;
-        border-radius: 3px;
-
-        input[name=chat-message] {
-          width: 100%;
-          background: none;
-          border: none;
-          height: $headerHeight;
-          line-height: $headerHeight;
-        }
-      }
-    }
-  }
-
-  aside {
-    section#user-list {
-      // TODO unify with other sidebar nav
-      background-color: rgba(0,255,255,0.2);
-      padding: 1.5em 0;
-
-      > ul {
-        list-style: none;
-
-        li {
-          a {
-            display: block;
-            padding: 0 1em;
-            height: 1.6em;
-            line-height: 1.6em;
-            &:hover {
-              background-color: rgba(255,255,255,0.2);
-            }
-          }
-        }
-      }
-    }
+    background-color: $background-color-cyan;
   }
 }
 

--- a/app/styles/components/channel-container.scss
+++ b/app/styles/components/channel-container.scss
@@ -1,5 +1,81 @@
 #channel {
 
+  main {
+    header {
+      display: flex;
+      align-items: stretch;
+      flex-direction: row;
+      justify-content: flex-start;
+
+      h2#channel-name {
+        flex: 0 0;
+        padding: 0 1rem;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        white-space: nowrap;
+        background-color: $background-color-magenta;
+        color: #fff;
+        transition: color 0.2s;
+
+        &.disconnected {
+          color: rgba(255,255,255,0.6);
+        }
+      }
+
+      p#channel-title {
+        flex: 1;
+        display: inline;
+        line-height: $headerHeight;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        padding: 0 1rem;
+        background-color: $background-color-magenta;
+        font-style: italic;
+        color: rgba(255,255,255,0.6);
+        transition: color 0.2s;
+
+        a {
+          color: rgba(255,255,255,0.6);
+        }
+
+        &:hover {
+          color: #fff;
+
+          a {
+            color: #fff;
+          }
+        }
+
+        @include media("<desktop") {
+          text-indent: -1000000px;
+        }
+      }
+
+      nav {
+        flex: 0 0 $sidebarWidth;
+
+        a {
+          background-color: $background-color-yellow;
+          &:hover  { background-color: rgba(255,255,255,0.3); }
+          &.active { background-color: $background-color-cyan; }
+
+          @include media("<desktop") {
+            background-color: $background-color-magenta;
+            &.active { background-color: $background-color-magenta; }
+          }
+        }
+      }
+    }
+
+    aside {
+      @include media("<desktop") {
+        display: none;
+      }
+    }
+  }
+
   #channel-content {
     padding: 0 1rem 1.5rem 1rem;
     background-color: #fff;
@@ -8,9 +84,11 @@
     a {
       color: #aaa;
       text-decoration: underline;
+
       &:hover {
         color: #333;
       }
+
       &.load-previous {
         display: block;
         padding-top: 1rem;
@@ -21,6 +99,7 @@
     ul {
       list-style: none;
       margin-bottom: 1.5rem;
+
       li {
         line-height: 1.5em;
         margin-bottom: 0.75em;

--- a/app/styles/components/channel-container.scss
+++ b/app/styles/components/channel-container.scss
@@ -70,8 +70,50 @@
     }
 
     aside {
+      section#user-list {
+        // TODO unify with other sidebar nav
+        background-color: $background-color-cyan;
+        padding: 1.5em 0;
+
+        > ul {
+          list-style: none;
+
+          li {
+            a {
+              display: block;
+              padding: 0 1em;
+              height: 1.6em;
+              line-height: 1.6em;
+
+              &:hover {
+                background-color: rgba(255,255,255,0.2);
+              }
+            }
+          }
+        }
+      }
+
       @include media("<desktop") {
         display: none;
+      }
+    }
+
+    footer {
+      background-color: #efefef;
+      color: #333;
+
+      section#new-message {
+        padding: 0 14px;
+        color: #fff;
+        border-radius: 3px;
+
+        input[name=chat-message] {
+          width: 100%;
+          background: none;
+          border: none;
+          height: $headerHeight;
+          line-height: $headerHeight;
+        }
       }
     }
   }

--- a/app/styles/vendor/_include_media.scss
+++ b/app/styles/vendor/_include_media.scss
@@ -1,0 +1,567 @@
+@charset "UTF-8";
+
+//     _            _           _                           _ _
+//    (_)          | |         | |                         | (_)
+//     _ _ __   ___| |_   _  __| | ___   _ __ ___   ___  __| |_  __ _
+//    | | '_ \ / __| | | | |/ _` |/ _ \ | '_ ` _ \ / _ \/ _` | |/ _` |
+//    | | | | | (__| | |_| | (_| |  __/ | | | | | |  __/ (_| | | (_| |
+//    |_|_| |_|\___|_|\__,_|\__,_|\___| |_| |_| |_|\___|\__,_|_|\__,_|
+//
+//      Simple, elegant and maintainable media queries in Sass
+//                        v1.4.9
+//
+//                http://include-media.com
+//
+//         Authors: Eduardo Boucas (@eduardoboucas)
+//                  Hugo Giraudel (@hugogiraudel)
+//
+//      This project is licensed under the terms of the MIT license
+
+
+////
+/// include-media library public configuration
+/// @author Eduardo Boucas
+/// @access public
+////
+
+
+///
+/// Creates a list of global breakpoints
+///
+/// @example scss - Creates a single breakpoint with the label `phone`
+///  $breakpoints: ('phone': 320px);
+///
+$breakpoints: (
+  'phone': 320px,
+  'tablet': 768px,
+  'desktop': 1024px
+) !default;
+
+
+///
+/// Creates a list of static expressions or media types
+///
+/// @example scss - Creates a single media type (screen)
+///  $media-expressions: ('screen': 'screen');
+///
+/// @example scss - Creates a static expression with logical disjunction (OR operator)
+///  $media-expressions: (
+///    'retina2x': '(-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi)'
+///  );
+///
+$media-expressions: (
+  'screen': 'screen',
+  'print': 'print',
+  'handheld': 'handheld',
+  'landscape': '(orientation: landscape)',
+  'portrait': '(orientation: portrait)',
+  'retina2x': '(-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi), (min-resolution: 2dppx)',
+  'retina3x': '(-webkit-min-device-pixel-ratio: 3), (min-resolution: 350dpi), (min-resolution: 3dppx)'
+) !default;
+
+
+///
+/// Defines a number to be added or subtracted from each unit when declaring breakpoints with exclusive intervals
+///
+/// @example scss - Interval for pixels is defined as `1` by default
+///  @include media('>128px') {}
+///
+///  /* Generates: */
+///  @media (min-width: 129px) {}
+///
+/// @example scss - Interval for ems is defined as `0.01` by default
+///  @include media('>20em') {}
+///
+///  /* Generates: */
+///  @media (min-width: 20.01em) {}
+///
+/// @example scss - Interval for rems is defined as `0.1` by default, to be used with `font-size: 62.5%;`
+///  @include media('>2.0rem') {}
+///
+///  /* Generates: */
+///  @media (min-width: 2.1rem) {}
+///
+$unit-intervals: (
+  'px': 1,
+  'em': 0.01,
+  'rem': 0.1,
+  '': 0
+) !default;
+
+///
+/// Defines whether support for media queries is available, useful for creating separate stylesheets
+/// for browsers that don't support media queries.
+///
+/// @example scss - Disables support for media queries
+///  $im-media-support: false;
+///  @include media('>=tablet') {
+///    .foo {
+///      color: tomato;
+///    }
+///  }
+///
+///  /* Generates: */
+///  .foo {
+///    color: tomato;
+///  }
+///
+$im-media-support: true !default;
+
+///
+/// Selects which breakpoint to emulate when support for media queries is disabled. Media queries that start at or
+/// intercept the breakpoint will be displayed, any others will be ignored.
+///
+/// @example scss - This media query will show because it intercepts the static breakpoint
+///  $im-media-support: false;
+///  $im-no-media-breakpoint: 'desktop';
+///  @include media('>=tablet') {
+///    .foo {
+///      color: tomato;
+///    }
+///  }
+///
+///  /* Generates: */
+///  .foo {
+///    color: tomato;
+///  }
+///
+/// @example scss - This media query will NOT show because it does not intercept the desktop breakpoint
+///  $im-media-support: false;
+///  $im-no-media-breakpoint: 'tablet';
+///  @include media('>=desktop') {
+///    .foo {
+///      color: tomato;
+///    }
+///  }
+///
+///  /* No output */
+///
+$im-no-media-breakpoint: 'desktop' !default;
+
+///
+/// Selects which media expressions are allowed in an expression for it to be used when media queries
+/// are not supported.
+///
+/// @example scss - This media query will show because it intercepts the static breakpoint and contains only accepted media expressions
+///  $im-media-support: false;
+///  $im-no-media-breakpoint: 'desktop';
+///  $im-no-media-expressions: ('screen');
+///  @include media('>=tablet', 'screen') {
+///    .foo {
+///      color: tomato;
+///    }
+///  }
+///
+///   /* Generates: */
+///   .foo {
+///     color: tomato;
+///   }
+///
+/// @example scss - This media query will NOT show because it intercepts the static breakpoint but contains a media expression that is not accepted
+///  $im-media-support: false;
+///  $im-no-media-breakpoint: 'desktop';
+///  $im-no-media-expressions: ('screen');
+///  @include media('>=tablet', 'retina2x') {
+///    .foo {
+///      color: tomato;
+///    }
+///  }
+///
+///  /* No output */
+///
+$im-no-media-expressions: ('screen', 'portrait', 'landscape') !default;
+
+////
+/// Cross-engine logging engine
+/// @author Hugo Giraudel
+/// @access private
+////
+
+
+///
+/// Log a message either with `@error` if supported
+/// else with `@warn`, using `feature-exists('at-error')`
+/// to detect support.
+///
+/// @param {String} $message - Message to log
+///
+@function im-log($message) {
+  @if feature-exists('at-error') {
+    @error $message;
+  } @else {
+    @warn $message;
+    $_: noop();
+  }
+
+  @return $message;
+}
+
+
+///
+/// Wrapper mixin for the log function so it can be used with a more friendly
+/// API than `@if im-log('..') {}` or `$_: im-log('..')`. Basically, use the function
+/// within functions because it is not possible to include a mixin in a function
+/// and use the mixin everywhere else because it's much more elegant.
+///
+/// @param {String} $message - Message to log
+///
+@mixin log($message) {
+  @if im-log($message) {}
+}
+
+
+///
+/// Function with no `@return` called next to `@warn` in Sass 3.3
+/// to trigger a compiling error and stop the process.
+///
+@function noop() {}
+
+///
+/// Determines whether a list of conditions is intercepted by the static breakpoint.
+///
+/// @param {Arglist}   $conditions  - Media query conditions
+///
+/// @return {Boolean} - Returns true if the conditions are intercepted by the static breakpoint
+///
+@function im-intercepts-static-breakpoint($conditions...) {
+  $no-media-breakpoint-value: map-get($breakpoints, $im-no-media-breakpoint);
+
+  @if not $no-media-breakpoint-value {
+    @if im-log('`#{$im-no-media-breakpoint}` is not a valid breakpoint.') {}
+  }
+
+  @each $condition in $conditions {
+    @if not map-has-key($media-expressions, $condition) {
+      $operator: get-expression-operator($condition);
+      $prefix: get-expression-prefix($operator);
+      $value: get-expression-value($condition, $operator);
+
+      @if ($prefix == 'max' and $value <= $no-media-breakpoint-value) or
+          ($prefix == 'min' and $value > $no-media-breakpoint-value) {
+        @return false;
+      }
+    } @else if not index($im-no-media-expressions, $condition) {
+      @return false;
+    }
+  }
+
+  @return true;
+}
+
+////
+/// Parsing engine
+/// @author Hugo Giraudel
+/// @access private
+////
+
+
+///
+/// Get operator of an expression
+///
+/// @param {String} $expression - Expression to extract operator from
+///
+/// @return {String} - Any of `>=`, `>`, `<=`, `<`, `≥`, `≤`
+///
+@function get-expression-operator($expression) {
+  @each $operator in ('>=', '>', '<=', '<', '≥', '≤') {
+    @if str-index($expression, $operator) {
+      @return $operator;
+    }
+  }
+
+  // It is not possible to include a mixin inside a function, so we have to
+  // rely on the `im-log(..)` function rather than the `log(..)` mixin. Because
+  // functions cannot be called anywhere in Sass, we need to hack the call in
+  // a dummy variable, such as `$_`. If anybody ever raise a scoping issue with
+  // Sass 3.3, change this line in `@if im-log(..) {}` instead.
+  $_: im-log('No operator found in `#{$expression}`.');
+}
+
+
+///
+/// Get dimension of an expression, based on a found operator
+///
+/// @param {String} $expression - Expression to extract dimension from
+/// @param {String} $operator - Operator from `$expression`
+///
+/// @return {String} - `width` or `height` (or potentially anything else)
+///
+@function get-expression-dimension($expression, $operator) {
+  $operator-index: str-index($expression, $operator);
+  $parsed-dimension: str-slice($expression, 0, $operator-index - 1);
+  $dimension: 'width';
+
+  @if str-length($parsed-dimension) > 0 {
+    $dimension: $parsed-dimension;
+  }
+
+  @return $dimension;
+}
+
+
+///
+/// Get dimension prefix based on an operator
+///
+/// @param {String} $operator - Operator
+///
+/// @return {String} - `min` or `max`
+///
+@function get-expression-prefix($operator) {
+  @return if(index(('<', '<=', '≤'), $operator), 'max', 'min');
+}
+
+
+///
+/// Get value of an expression, based on a found operator
+///
+/// @param {String} $expression - Expression to extract value from
+/// @param {String} $operator - Operator from `$expression`
+///
+/// @return {Number} - A numeric value
+///
+@function get-expression-value($expression, $operator) {
+  $operator-index: str-index($expression, $operator);
+  $value: str-slice($expression, $operator-index + str-length($operator));
+
+  @if map-has-key($breakpoints, $value) {
+    $value: map-get($breakpoints, $value);
+  } @else {
+    $value: to-number($value);
+  }
+
+  $interval: map-get($unit-intervals, unit($value));
+
+  @if not $interval {
+    // It is not possible to include a mixin inside a function, so we have to
+    // rely on the `im-log(..)` function rather than the `log(..)` mixin. Because
+    // functions cannot be called anywhere in Sass, we need to hack the call in
+    // a dummy variable, such as `$_`. If anybody ever raise a scoping issue with
+    // Sass 3.3, change this line in `@if im-log(..) {}` instead.
+    $_: im-log('Unknown unit `#{unit($value)}`.');
+  }
+
+  @if $operator == '>' {
+    $value: $value + $interval;
+  } @else if $operator == '<' {
+    $value: $value - $interval;
+  }
+
+  @return $value;
+}
+
+
+///
+/// Parse an expression to return a valid media-query expression
+///
+/// @param {String} $expression - Expression to parse
+///
+/// @return {String} - Valid media query
+///
+@function parse-expression($expression) {
+  // If it is part of $media-expressions, it has no operator
+  // then there is no need to go any further, just return the value
+  @if map-has-key($media-expressions, $expression) {
+    @return map-get($media-expressions, $expression);
+  }
+
+  $operator: get-expression-operator($expression);
+  $dimension: get-expression-dimension($expression, $operator);
+  $prefix: get-expression-prefix($operator);
+  $value: get-expression-value($expression, $operator);
+
+  @return '(#{$prefix}-#{$dimension}: #{$value})';
+}
+
+///
+/// Slice `$list` between `$start` and `$end` indexes
+///
+/// @access private
+///
+/// @param {List} $list - List to slice
+/// @param {Number} $start [1] - Start index
+/// @param {Number} $end [length($list)] - End index
+///
+/// @return {List} Sliced list
+///
+@function slice($list, $start: 1, $end: length($list)) {
+  @if length($list) < 1 or $start > $end {
+    @return ();
+  }
+
+  $result: ();
+
+  @for $i from $start through $end {
+    $result: append($result, nth($list, $i));
+  }
+
+  @return $result;
+}
+
+////
+/// String to number converter
+/// @author Hugo Giraudel
+/// @access private
+////
+
+
+///
+/// Casts a string into a number
+///
+/// @param {String | Number} $value - Value to be parsed
+///
+/// @return {Number}
+///
+@function to-number($value) {
+  @if type-of($value) == 'number' {
+    @return $value;
+  } @else if type-of($value) != 'string' {
+    $_: im-log('Value for `to-number` should be a number or a string.');
+  }
+
+  $first-character: str-slice($value, 1, 1);
+  $result: 0;
+  $digits: 0;
+  $minus: ($first-character == '-');
+  $numbers: ('0': 0, '1': 1, '2': 2, '3': 3, '4': 4, '5': 5, '6': 6, '7': 7, '8': 8, '9': 9);
+
+  // Remove +/- sign if present at first character
+  @if ($first-character == '+' or $first-character == '-') {
+    $value: str-slice($value, 2);
+  }
+
+  @for $i from 1 through str-length($value) {
+    $character: str-slice($value, $i, $i);
+
+    @if not (index(map-keys($numbers), $character) or $character == '.') {
+      @return to-length(if($minus, -$result, $result), str-slice($value, $i))
+    }
+
+    @if $character == '.' {
+      $digits: 1;
+    } @else if $digits == 0 {
+      $result: $result * 10 + map-get($numbers, $character);
+    } @else {
+      $digits: $digits * 10;
+      $result: $result + map-get($numbers, $character) / $digits;
+    }
+  }
+
+  @return if($minus, -$result, $result);
+}
+
+
+///
+/// Add `$unit` to `$value`
+///
+/// @param {Number} $value - Value to add unit to
+/// @param {String} $unit - String representation of the unit
+///
+/// @return {Number} - `$value` expressed in `$unit`
+///
+@function to-length($value, $unit) {
+  $units: ('px': 1px, 'cm': 1cm, 'mm': 1mm, '%': 1%, 'ch': 1ch, 'pc': 1pc, 'in': 1in, 'em': 1em, 'rem': 1rem, 'pt': 1pt, 'ex': 1ex, 'vw': 1vw, 'vh': 1vh, 'vmin': 1vmin, 'vmax': 1vmax);
+
+  @if not index(map-keys($units), $unit) {
+    $_: im-log('Invalid unit `#{$unit}`.');
+  }
+
+  @return $value * map-get($units, $unit);
+}
+
+///
+/// This mixin aims at redefining the configuration just for the scope of
+/// the call. It is helpful when having a component needing an extended
+/// configuration such as custom breakpoints (referred to as tweakpoints)
+/// for instance.
+///
+/// @author Hugo Giraudel
+///
+/// @param {Map} $tweakpoints [()] - Map of tweakpoints to be merged with `$breakpoints`
+/// @param {Map} $tweak-media-expressions [()] - Map of tweaked media expressions to be merged with `$media-expression`
+///
+/// @example scss - Extend the global breakpoints with a tweakpoint
+///  @include media-context(('custom': 678px)) {
+///    .foo {
+///      @include media('>phone', '<=custom') {
+///       // ...
+///      }
+///    }
+///  }
+///
+/// @example scss - Extend the global media expressions with a custom one
+///  @include media-context($tweak-media-expressions: ('all': 'all')) {
+///    .foo {
+///      @include media('all', '>phone') {
+///       // ...
+///      }
+///    }
+///  }
+///
+/// @example scss - Extend both configuration maps
+///  @include media-context(('custom': 678px), ('all': 'all')) {
+///    .foo {
+///      @include media('all', '>phone', '<=custom') {
+///       // ...
+///      }
+///    }
+///  }
+///
+@mixin media-context($tweakpoints: (), $tweak-media-expressions: ()) {
+  // Save global configuration
+  $global-breakpoints: $breakpoints;
+  $global-media-expressions: $media-expressions;
+
+  // Update global configuration
+  $breakpoints: map-merge($breakpoints, $tweakpoints) !global;
+  $media-expressions: map-merge($media-expressions, $tweak-media-expressions) !global;
+
+  @content;
+
+  // Restore global configuration
+  $breakpoints: $global-breakpoints !global;
+  $media-expressions: $global-media-expressions !global;
+}
+
+////
+/// include-media public exposed API
+/// @author Eduardo Boucas
+/// @access public
+////
+
+
+///
+/// Generates a media query based on a list of conditions
+///
+/// @param {Arglist}   $conditions  - Media query conditions
+///
+/// @example scss - With a single set breakpoint
+///  @include media('>phone') { }
+///
+/// @example scss - With two set breakpoints
+///  @include media('>phone', '<=tablet') { }
+///
+/// @example scss - With custom values
+///  @include media('>=358px', '<850px') { }
+///
+/// @example scss - With set breakpoints with custom values
+///  @include media('>desktop', '<=1350px') { }
+///
+/// @example scss - With a static expression
+///  @include media('retina2x') { }
+///
+/// @example scss - Mixing everything
+///  @include media('>=350px', '<tablet', 'retina3x') { }
+///
+@mixin media($conditions...) {
+  @if ($im-media-support and length($conditions) == 0) or
+      (not $im-media-support and im-intercepts-static-breakpoint($conditions...)) {
+    @content;
+  } @else if ($im-media-support and length($conditions) > 0) {
+    @media #{unquote(parse-expression(nth($conditions, 1)))} {
+      // Recursive call
+      @include media(slice($conditions, 2)...) {
+        @content;
+      }
+    }
+  }
+}


### PR DESCRIPTION
* Make the channel's nav part of the channel header, so it is independent of the sidebar
* Use flexbox layout for the channel header
* Show channel nav on mobile (prep for new content sidebars)
* Fix long channel topics breaking the layout (use ellipsis for overflow)
* Make channel topic less opaque until hovering it

![Screenshot from 2020-01-11 12-55-06](https://user-images.githubusercontent.com/842/72208655-43b46280-3473-11ea-8062-9cf6882ae8e8.png)
![Screenshot from 2020-01-11 12-54-42](https://user-images.githubusercontent.com/842/72208656-444cf900-3473-11ea-812f-445893870c9d.png)

fixes #51