### PR TITLE
Octanify channel-nav, message-input

### DIFF
--- a/.template-lintrc.js
+++ b/.template-lintrc.js
@@ -4,7 +4,8 @@ module.exports = {
   extends: 'octane',
 
   rules: {
-    'no-invalid-interactive': false
+    'no-invalid-interactive': false,
+    'link-href-attributes': false
   },
 
   pending: [
@@ -18,16 +19,6 @@ module.exports = {
       "moduleId": "app/components/channel-container/template",
       "only": [
         "link-rel-noopener",
-        "link-href-attributes",
-        "no-action",
-        "no-curly-component-invocation",
-        "no-implicit-this"
-      ]
-    },
-    {
-      "moduleId": "app/components/channel-nav/template",
-      "only": [
-        "link-href-attributes",
         "no-action",
         "no-curly-component-invocation",
         "no-implicit-this"
@@ -58,14 +49,6 @@ module.exports = {
     {
       "moduleId": "app/components/message-chat-me/template",
       "only": [
-        "no-curly-component-invocation",
-        "no-implicit-this"
-      ]
-    },
-    {
-      "moduleId": "app/components/message-input/template",
-      "only": [
-        "no-action",
         "no-curly-component-invocation",
         "no-implicit-this"
       ]
@@ -126,16 +109,6 @@ module.exports = {
       "moduleId": "hyperchannel/components/channel-container/template",
       "only": [
         "link-rel-noopener",
-        "link-href-attributes",
-        "no-action",
-        "no-curly-component-invocation",
-        "no-implicit-this"
-      ]
-    },
-    {
-      "moduleId": "hyperchannel/components/channel-nav/template",
-      "only": [
-        "link-href-attributes",
         "no-action",
         "no-curly-component-invocation",
         "no-implicit-this"
@@ -164,14 +137,6 @@ module.exports = {
     },
     {
       "moduleId": "hyperchannel/components/message-chat/template",
-      "only": [
-        "no-action",
-        "no-curly-component-invocation",
-        "no-implicit-this"
-      ]
-    },
-    {
-      "moduleId": "hyperchannel/components/message-input/template",
       "only": [
         "no-action",
         "no-curly-component-invocation",

--- a/.template-lintrc.js
+++ b/.template-lintrc.js
@@ -23,17 +23,6 @@ module.exports = {
     {
       "moduleId": "app/components/channel-container/template",
       "only": [
-        "link-rel-noopener",
-        "link-href-attributes",
-        "no-action",
-        "no-curly-component-invocation",
-        "no-implicit-this"
-      ]
-    },
-    {
-      "moduleId": "app/components/channel-nav/template",
-      "only": [
-        "link-href-attributes",
         "no-action",
         "no-curly-component-invocation",
         "no-implicit-this"
@@ -122,16 +111,6 @@ module.exports = {
     },
     {
       "moduleId": "hyperchannel/components/channel-container/template",
-      "only": [
-        "link-rel-noopener",
-        "link-href-attributes",
-        "no-action",
-        "no-curly-component-invocation",
-        "no-implicit-this"
-      ]
-    },
-    {
-      "moduleId": "hyperchannel/components/channel-nav/template",
       "only": [
         "no-action",
         "no-curly-component-invocation",

--- a/app/components/channel-container/component.js
+++ b/app/components/channel-container/component.js
@@ -79,11 +79,14 @@ export default Component.extend({
 
   actions: {
 
-    processMessageOrCommand () {
-      if (this.newMessage.substr(0, 1) === "/") {
-        this.onCommand(this.newMessage);
+    processMessageOrCommand (e) {
+      if (e && e.preventDefault) e.preventDefault();
+      const msg = document.querySelector('input#message-field').value;
+
+      if (msg.substr(0, 1) === "/") {
+        this.onCommand(msg);
       } else {
-        this.onMessage(this.newMessage);
+        this.onMessage(msg);
       }
     },
 
@@ -111,7 +114,7 @@ export default Component.extend({
 
     leaveChannel (space, channel) {
       this.onLeaveChannel(space, channel);
-    },
+    }
 
   }
 });

--- a/app/components/channel-container/template.hbs
+++ b/app/components/channel-container/template.hbs
@@ -3,10 +3,10 @@
     <h2 id="channel-name"
         class={{if this.channel.connected "connected" "disconnected"}}
         {{action "menu" "global" "toggle"}}>
-      {{this.channelname}}
+      {{this.channel.name}}
     </h2>
     <p id="channel-title">
-      {{this.channelformattedTopic}}
+      {{this.channel.formattedTopic}}
     </p>
     <nav>
       <LinkTo @route="index" class="active"><IconUsers /></LinkTo><a><IconPaperclip /></a><a><IconSettings /></a><a {{action "leaveChannel" this.space this.channel}} title="Leave {{this.channelname}}"><IconLogOut /></a>

--- a/app/components/channel-container/template.hbs
+++ b/app/components/channel-container/template.hbs
@@ -53,14 +53,14 @@
       </section>
 
       <footer>
-        {{message-input message=newMessage
-                        onSend=(action "processMessageOrCommand")
-                        usernames=channel.userList}}
+        <MessageInput @message={{newMessage}}
+                      @sendMessage={{action "processMessageOrCommand"}}
+                      @usernames={{channel.userList}} />
       </footer>
     </div>
 
     <aside>
-      {{user-list users=channel.sortedUserList}}
+      <UserList @users={{channel.sortedUserList}} />
     </aside>
   </div>
 </main>

--- a/app/components/channel-nav/component.js
+++ b/app/components/channel-nav/component.js
@@ -49,12 +49,12 @@ export default class ChannelNavComponent extends Component {
   }
 
   @action
-  didInsertNode (element) {
+  bindKeyboardShortcuts (element) {
     bindKeyboardShortcuts(this, element);
   }
 
   @action
-  willDestroyNode (element) {
+  unbindKeyboardShortcuts (element) {
     unbindKeyboardShortcuts(this, element);
   }
 

--- a/app/components/channel-nav/component.js
+++ b/app/components/channel-nav/component.js
@@ -1,38 +1,24 @@
-import Component from '@ember/component';
-import { isEmpty, isPresent } from '@ember/utils';
-import { computed } from '@ember/object';
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
-import {
-  bindKeyboardShortcuts,
-  unbindKeyboardShortcuts
-} from 'ember-keyboard-shortcuts';
+import { isEmpty, isPresent } from '@ember/utils';
+import { bindKeyboardShortcuts, unbindKeyboardShortcuts } from 'ember-keyboard-shortcuts';
 
-export default Component.extend({
+export default class ChannelNavComponent extends Component {
 
-  tagName: 'ul',
-  router: service(),
-  coms: service(),
-  storage: service('remotestorage'),
+  @service router;
+  @service coms;
+  @service('remotestorage') storage;
 
-  keyboardShortcuts: Object.freeze({
+  keyboardShortcuts = Object.freeze({
     'ctrl+shift+up': 'goPreviousChannel',
     'ctrl+shift+down': 'goNextChannel'
-  }),
+  })
 
-  didInsertElement () {
-    this._super(...arguments);
-    bindKeyboardShortcuts(this);
-  },
-
-  willDestroyElement () {
-    this._super(...arguments);
-    unbindKeyboardShortcuts(this);
-  },
-
-  activeChannel: computed('spaces.@each.activeChannel', function () {
+  get activeChannel () {
     let activeChannel;
 
-    this.spaces.forEach(function (space) {
+    this.args.spaces.forEach(space => {
       let channel = space.activeChannel;
       if (isPresent(channel)) {
         activeChannel = channel;
@@ -40,7 +26,7 @@ export default Component.extend({
     });
 
     return activeChannel;
-  }),
+  }
 
   transitionToRelativeChannel (relativePosition) {
     if (isPresent(this.activeChannel)) {
@@ -57,37 +43,45 @@ export default Component.extend({
 
       let newPosition = currentPosition === edge ? edgeOpposite : currentPosition + relativePosition;
       let newChannel = channels[newPosition];
+
       this.router.transitionTo('space.channel', newChannel.space, newChannel);
-    }
-  },
-
-  actions: {
-    joinChannel (space) {
-      let channelName = window.prompt('Join channel');
-
-      if (isEmpty(channelName)) {
-        return;
-      }
-
-      if (space.get('protocol') === 'IRC' && !channelName.match(/^#/)) {
-        channelName = `#${channelName}`;
-      }
-      let channel = this.coms.createChannel(space, channelName);
-      this.storage.saveSpace(space);
-      this.router.transitionTo('space.channel', space, channel);
-    },
-
-    leaveChannel (space, channel) {
-      this.onLeaveChannel(space, channel);
-    },
-
-    goPreviousChannel () {
-      this.transitionToRelativeChannel(-1);
-    },
-
-    goNextChannel () {
-      this.transitionToRelativeChannel(1);
     }
   }
 
-});
+  @action
+  didInsertNode (element) {
+    bindKeyboardShortcuts(this, element);
+  }
+
+  @action
+  willDestroyNode (element) {
+    unbindKeyboardShortcuts(this, element);
+  }
+
+  @action
+  joinChannel (space) {
+    let channelName = window.prompt('Join channel');
+
+    if (isEmpty(channelName)) {
+      return;
+    }
+
+    if (space.get('protocol') === 'IRC' && !channelName.match(/^#/)) {
+      channelName = `#${channelName}`;
+    }
+    let channel = this.coms.createChannel(space, channelName);
+    this.storage.saveSpace(space);
+    this.router.transitionTo('space.channel', space, channel);
+  }
+
+  @action
+  goPreviousChannel () {
+    this.transitionToRelativeChannel(-1);
+  }
+
+  @action
+  goNextChannel () {
+    this.transitionToRelativeChannel(1);
+  }
+
+}

--- a/app/components/channel-nav/template.hbs
+++ b/app/components/channel-nav/template.hbs
@@ -1,5 +1,5 @@
-<ul {{did-insert this.didInsertNode}} {{will-destroy this.willDestroyNode}}>
-  {{#each this.spaces as |space|}}
+<ul {{did-insert this.bindKeyboardShortcuts}}
+    {{will-destroy this.unbindKeyboardShortcuts}}>
   {{#each @spaces as |space|}}
     <li>
       <h2><LinkTo @route="space" @model={{space}}>{{space.name}}</LinkTo></h2>

--- a/app/components/channel-nav/template.hbs
+++ b/app/components/channel-nav/template.hbs
@@ -1,5 +1,6 @@
 <ul {{did-insert this.didInsertNode}} {{will-destroy this.willDestroyNode}}>
   {{#each this.spaces as |space|}}
+  {{#each @spaces as |space|}}
     <li>
       <h2><LinkTo @route="space" @model={{space}}>{{space.name}}</LinkTo></h2>
       <ul>

--- a/app/components/channel-nav/template.hbs
+++ b/app/components/channel-nav/template.hbs
@@ -1,20 +1,22 @@
-{{#each spaces as |space|}}
-  <li>
-    <h2>{{#link-to "space" space}}{{space.name}}{{/link-to}}</h2>
-    <ul>
-      {{#each space.sortedChannels as |channel|}}
-        <li class="{{if channel.connected "connected" "disconnected"}} {{channel.unreadMessagesClass}} {{if channel.visible "active" ""}}">
-          {{#if channel.isUserChannel}}
-            {{#link-to "space.user-channel" space channel}}{{channel.name}}{{/link-to}}
-          {{else}}
-            {{#link-to "space.channel" space channel}}{{channel.name}}{{/link-to}}
-          {{/if}}
-          <a {{action "leaveChannel" space channel}} class="leave-channel" title="Leave {{channel.name}}">x</a>
+<ul {{did-insert this.didInsertNode}} {{will-destroy this.willDestroyNode}}>
+  {{#each this.spaces as |space|}}
+    <li>
+      <h2><LinkTo @route="space" @model={{space}}>{{space.name}}</LinkTo></h2>
+      <ul>
+        {{#each space.sortedChannels as |channel|}}
+          <li class="{{if channel.connected "connected" "disconnected"}} {{channel.unreadMessagesClass}} {{if channel.visible "active" ""}}">
+            {{#if channel.isUserChannel}}
+              <LinkTo @route="space.user-channel" @models={{array space channel}}>{{channel.name}}</LinkTo>
+            {{else}}
+              <LinkTo @route="space.channel" @models={{array space channel}}>{{channel.name}}</LinkTo>
+            {{/if}}
+            <a {{on "click" (fn @onLeaveChannel space channel)}} class="leave-channel" title="Leave {{channel.name}}">x</a>
+          </li>
+        {{/each}}
+        <li>
+          <a {{on "click" (fn this.joinChannel space)}} class="join-channel" role="button">+</a>
         </li>
-      {{/each}}
-      <li>
-        <a {{action "joinChannel" space}} class="join-channel" role="button">+</a>
-      </li>
-    </ul>
-  </li>
-{{/each}}
+      </ul>
+    </li>
+  {{/each}}
+</ul>

--- a/app/components/message-input/component.js
+++ b/app/components/message-input/component.js
@@ -19,12 +19,12 @@ export default class MessageInputComponent extends Component {
   }
 
   @action
-  didInsertNode (element) {
+  bindKeyboardShortcuts (element) {
     bindKeyboardShortcuts(this, element);
   }
 
   @action
-  willDestroyNode (element) {
+  unbindKeyboardShortcuts (element) {
     unbindKeyboardShortcuts(this, element);
   }
 

--- a/app/components/message-input/component.js
+++ b/app/components/message-input/component.js
@@ -1,73 +1,66 @@
-import Component from '@ember/component';
-import {
-  bindKeyboardShortcuts,
-  unbindKeyboardShortcuts
-} from 'ember-keyboard-shortcuts';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
 import { isEmpty } from '@ember/utils';
+import { action } from '@ember/object';
 import { scheduleOnce } from '@ember/runloop';
+import { bindKeyboardShortcuts, unbindKeyboardShortcuts } from 'ember-keyboard-shortcuts';
 
-export default Component.extend({
+export default class MessageInputComponent extends Component {
 
-  tagName: 'section',
-  elementId: 'new-message',
+  @tracked message = '';
 
-  message: '',
-  usernames: null,
-
-  keyboardShortcuts: Object.freeze({
+  keyboardShortcuts = Object.freeze({
     'tab': 'completeUsername'
-  }),
-
-  didInsertElement () {
-    this._super(...arguments);
-    bindKeyboardShortcuts(this);
-  },
-
-  willDestroyElement () {
-    this._super(...arguments);
-    unbindKeyboardShortcuts(this);
-  },
+  });
 
   setCursorPosition (input, newCursorPosition) {
     input.focus();
     input.setSelectionRange(newCursorPosition, newCursorPosition);
-  },
-
-  actions: {
-
-    completeUsername () {
-      const input = this.element.querySelector('#message-field');
-      const cursorPosition = input.selectionStart;
-      const textBeforeCursor = this.message.slice(0, cursorPosition);
-      const textAfterCursor = this.message.slice(cursorPosition);
-      const words = textBeforeCursor.split(' ');
-      const searchWord = words.pop();
-
-      if (isEmpty(searchWord)) return;
-
-      let username = this.usernames.find(username => {
-        return username.toLowerCase().startsWith(searchWord.toLowerCase());
-      });
-
-      if (isEmpty(username)) return;
-
-      // add a colon when inserting the username in the beginning
-      if (words.length === 0) {
-        username = `${username}: `;
-      }
-
-      const lengthDiff = username.length - searchWord.length;
-      const newCursorPosition = cursorPosition + lengthDiff;
-
-      words.push(username);
-      const newMessage = `${words.join(' ')}${textAfterCursor}`;
-      this.set('message', newMessage);
-
-      // set the cursor right behind the inserted username,
-      // but we have to wait for the update of the input first
-      scheduleOnce('afterRender', this, 'setCursorPosition', input, newCursorPosition);
-    }
-
   }
 
-});
+  @action
+  didInsertNode (element) {
+    bindKeyboardShortcuts(this, element);
+  }
+
+  @action
+  willDestroyNode (element) {
+    unbindKeyboardShortcuts(this, element);
+  }
+
+  @action
+  completeUsername () {
+    const input = document.querySelector('input#message-field');
+    const message = input.value;
+    const cursorPosition = input.selectionStart;
+    const textBeforeCursor = message.slice(0, cursorPosition);
+    const textAfterCursor = message.slice(cursorPosition);
+    const words = textBeforeCursor.split(' ');
+    const searchWord = words.pop();
+
+    if (isEmpty(searchWord)) return;
+
+    let username = this.args.usernames.find(username => {
+      return username.toLowerCase().startsWith(searchWord.toLowerCase());
+    });
+
+    if (isEmpty(username)) return;
+
+    // add a colon when inserting the username in the beginning
+    if (words.length === 0) {
+      username = `${username}: `;
+    }
+
+    const lengthDiff = username.length - searchWord.length;
+    const newCursorPosition = cursorPosition + lengthDiff;
+
+    words.push(username);
+    const newMessage = `${words.join(' ')}${textAfterCursor}`;
+    input.value = newMessage;
+
+    // set the cursor right behind the inserted username,
+    // but we have to wait for the update of the input first
+    scheduleOnce('afterRender', this, 'setCursorPosition', input, newCursorPosition);
+  }
+
+}

--- a/app/components/message-input/template.hbs
+++ b/app/components/message-input/template.hbs
@@ -1,7 +1,9 @@
-<form {{action onSend on="submit"}}>
-  {{channel-input-field value=message
-                        placeholder="Type a message and hit enter"
-                        name="chat-message"
-                        id="message-field"
-                        autocomplete="off"}}
-</form>
+<section id="new-message" {{did-insert this.didInsertNode}} {{will-destroy this.willDestroyNode}}>
+  <form {{on "submit" @sendMessage}}>
+    <ChannelInputField @value={{@message}}
+                       @placeholder="Type a message and hit enter"
+                       @name="chat-message"
+                       @id="message-field"
+                       @autocomplete="off" />
+  </form>
+</section>

--- a/app/components/message-input/template.hbs
+++ b/app/components/message-input/template.hbs
@@ -1,4 +1,6 @@
-<section id="new-message" {{did-insert this.didInsertNode}} {{will-destroy this.willDestroyNode}}>
+<section id="new-message"
+         {{did-insert this.bindKeyboardShortcuts}}
+         {{will-destroy this.unbindKeyboardShortcuts}}>
   <form {{on "submit" @sendMessage}}>
     <ChannelInputField @value={{@message}}
                        @placeholder="Type a message and hit enter"

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -1,4 +1,5 @@
-<AppContainer @showGlobalMenu={{this.showGlobalMenu}} @showChannelMenu={{this.showChannelMenu}}>
+<AppContainer @showGlobalMenu={{this.showGlobalMenu}}
+              @showChannelMenu={{this.showChannelMenu}}>
   <div id="global">
     <header id="sitename">
       <h1>Kosmos</h1>
@@ -6,7 +7,8 @@
 
     <div class="main">
       <nav id="channels">
-        <ChannelNav @spaces={{this.spaces}} @onLeaveChannel={{route-action "leaveChannel"}} />
+        <ChannelNav @spaces={{this.spaces}}
+                    @onLeaveChannel={{route-action "leaveChannel"}} />
       </nav>
     </div>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1305,6 +1305,16 @@
         }
       }
     },
+    "@ember/render-modifiers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@ember/render-modifiers/-/render-modifiers-1.0.2.tgz",
+      "integrity": "sha512-6tEnHl5+62NTSAG2mwhGMFPhUrJQjoVqV+slsn+rlTknm2Zik+iwxBQEbwaiQOU1FUYxkS8RWcieovRNMR8inQ==",
+      "dev": true,
+      "requires": {
+        "ember-cli-babel": "^7.10.0",
+        "ember-modifier-manager-polyfill": "^1.1.0"
+      }
+    },
     "@ember/test-helpers": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/@ember/test-helpers/-/test-helpers-1.7.1.tgz",
@@ -10809,9 +10819,8 @@
       }
     },
     "ember-keyboard-shortcuts": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/ember-keyboard-shortcuts/-/ember-keyboard-shortcuts-1.2.0.tgz",
-      "integrity": "sha512-wMSl5TSXBaRd3zqvS1pKkEkIUzQMhP2zkZIqePmH+ddF6MGherTDxtriX9CFdywP72kcxYvzR7GAWPliiJ/pfw==",
+      "version": "github:67P/ember-keyboard-shortcuts#637736711a060651ce0c694c17514fdc677ac64b",
+      "from": "github:67P/ember-keyboard-shortcuts#feature/octane_classes",
       "dev": true,
       "requires": {
         "broccoli-funnel": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "devDependencies": {
     "@67p/ember-service-worker-hubot-web-push-notifications": "^1.0.1",
     "@ember/optional-features": "^1.1.0",
+    "@ember/render-modifiers": "^1.0.2",
     "@glimmer/component": "^1.0.0",
     "autoprefixer": "^7.2.6",
     "babel-eslint": "^10.0.3",
@@ -65,7 +66,7 @@
     "ember-fetch": "^7.0.0",
     "ember-gestures": "^1.1.5",
     "ember-hammertime": "1.6.0",
-    "ember-keyboard-shortcuts": "^1.2.0",
+    "ember-keyboard-shortcuts": "github:67P/ember-keyboard-shortcuts#feature/octane_classes",
     "ember-load-initializers": "^2.1.1",
     "ember-local-storage": "^1.7.1",
     "ember-maybe-import-regenerator": "^0.1.6",

--- a/tests/helpers/create-component.js
+++ b/tests/helpers/create-component.js
@@ -1,0 +1,9 @@
+import { getContext } from '@ember/test-helpers';
+import GlimmerComponentManager from '../../component-managers/glimmer';
+
+export default function createComponent(lookupPath, named = {}) {
+  let { owner } = getContext();
+  let { class: componentClass } = owner.factoryFor(lookupPath);
+  let componentManager = new GlimmerComponentManager(owner);
+  return componentManager.createComponent(componentClass, { named });
+}

--- a/tests/unit/components/channel-nav-test.js
+++ b/tests/unit/components/channel-nav-test.js
@@ -1,16 +1,18 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
+import { run } from '@ember/runloop';
 import Service from '@ember/service';
 import Channel from 'hyperchannel/models/channel';
 import Space from 'hyperchannel/models/space';
-import { run } from '@ember/runloop';
+import createComponent from 'hyperchannel/tests/helpers/create-component';
 
 const routerStub = Service.extend({
+  foo: 'bar',
+
   transitionTo (route, space, channel) {
     this.set('currentRoute', route);
     this.set('currentSpace', space);
     this.set('currentChannel', channel);
-
     return true;
   }
 });
@@ -25,7 +27,7 @@ module('Unit | Component | channel-nav', function (hooks) {
     space.channels.pushObject(channel);
     space.channels.pushObject(channel2);
 
-    const component = this.owner.factoryFor('component:channel-nav').create({ spaces: [space] });
+    const component = createComponent('component:channel-nav', { spaces: [space] });
 
     assert.equal(component.activeChannel, channel2);
   });
@@ -38,13 +40,10 @@ module('Unit | Component | channel-nav', function (hooks) {
     space.set('channels', [channel2, channel1, channel3]);
 
     const routerService = routerStub.create();
+    const component = createComponent('component:channel-nav', { spaces: [space] });
+    component.router = routerService;
 
-    const component = this.owner.factoryFor('component:channel-nav').create({
-      router: routerService,
-      spaces: [space]
-    });
-
-    run(() => component.send('goNextChannel'));
+    run(() => component.goNextChannel());
 
     assert.equal(routerService.currentRoute, 'space.channel');
     assert.equal(routerService.currentSpace, space);
@@ -52,7 +51,7 @@ module('Unit | Component | channel-nav', function (hooks) {
 
     channel2.set('visible', false);
     channel3.set('visible', true);
-    run(() => component.send('goNextChannel'));
+    run(() => component.goNextChannel());
 
     assert.equal(routerService.currentChannel.name, channel1.name);
   });
@@ -65,13 +64,10 @@ module('Unit | Component | channel-nav', function (hooks) {
     space.set('channels', [channel1, channel3, channel2]);
 
     const routerService = routerStub.create();
+    const component = createComponent('component:channel-nav', { spaces: [space] });
+    component.router = routerService;
 
-    const component = this.owner.factoryFor('component:channel-nav').create({
-      router: routerService,
-      spaces: [space]
-    });
-
-    run(() => component.send('goPreviousChannel'));
+    run(() => component.goPreviousChannel());
 
     assert.equal(routerService.currentRoute, 'space.channel');
     assert.equal(routerService.currentSpace, space);
@@ -79,7 +75,7 @@ module('Unit | Component | channel-nav', function (hooks) {
 
     channel1.set('visible', true);
     channel2.set('visible', false);
-    run(() => component.send('goPreviousChannel'));
+    run(() => component.goPreviousChannel());
 
     assert.equal(routerService.currentChannel.name, channel3.name);
   });


### PR DESCRIPTION
Needed to fork ember-keyboard-shortcuts to add Octane support.

Unit tests are not generally a thing for Glimmer components, and I think ours should actually be rewritten as acceptance tests. But to make it work for now, I used the solution described in
https://timgthomas.com/2019/11/unit-testing-glimmer-components/

refs #184 