### PR TITLE
Channel sidebar tabs/content

### DIFF
--- a/.template-lintrc.js
+++ b/.template-lintrc.js
@@ -25,7 +25,8 @@ module.exports = {
       "only": [
         "no-action",
         "no-curly-component-invocation",
-        "no-implicit-this"
+        "no-implicit-this",
+        "no-outlet-outside-routes"
       ]
     },
     {
@@ -114,7 +115,8 @@ module.exports = {
       "only": [
         "no-action",
         "no-curly-component-invocation",
-        "no-implicit-this"
+        "no-implicit-this",
+        "no-outlet-outside-routes"
       ]
     },
     {

--- a/app/components/app-container/component.js
+++ b/app/components/app-container/component.js
@@ -45,6 +45,9 @@ export default Component.extend(RecognizerMixin, {
         !isDescendantOf('channel-header', e.target) &&
         !isDescendantOf('global', e.target)) {
       this.set('showGlobalMenu', false);
+    } else if (this.showChannelMenu &&
+        !isDescendantOf('channel-sidebar', e.target)) {
+      this.set('showChannelMenu', false);
     }
   }
 

--- a/app/components/channel-container/template.hbs
+++ b/app/components/channel-container/template.hbs
@@ -24,7 +24,7 @@
     </nav>
   </header>
 
-  <div class="content-container {{if this.showChannelMenu "channel-menu-open"}}">
+  <div class="content-container {{this.sidebarClass}} {{if this.showChannelMenu "channel-menu-open"}}">
     <div class="content">
       <section id="channel-content" class="main">
         {{#if this.channel.isLogged}}

--- a/app/components/channel-container/template.hbs
+++ b/app/components/channel-container/template.hbs
@@ -9,11 +9,11 @@
       {{this.channel.formattedTopic}}
     </p>
     <nav>
-      <button type="button"
-              {{action "menu" "channel" "toggle"}}
-              class={{if this.headerNavButtonUsersActive "active"}}>
+      <LinkTo @route="space.channel.index"
+              @models={{array space channel}}
+              {{action "menu" "channel" "show"}}>
         <IconUsers />
-      </button>
+      </LinkTo>
       <a><IconPaperclip /></a><a><IconSettings /></a><a {{action "leaveChannel" this.space this.channel}} title="Leave {{this.channelname}}"><IconLogOut /></a>
     </nav>
   </header>
@@ -64,8 +64,8 @@
       </footer>
     </div>
 
-    <aside>
-      <UserList @users={{this.channel.sortedUserList}} />
+    <aside id="channel-sidebar">
+      {{outlet}}
     </aside>
   </div>
 </main>

--- a/app/components/channel-container/template.hbs
+++ b/app/components/channel-container/template.hbs
@@ -9,12 +9,18 @@
       {{this.channel.formattedTopic}}
     </p>
     <nav>
-      <LinkTo @route="space.channel.index"
-              @models={{array space channel}}
-              {{action "menu" "channel" "show"}}>
+      <LinkTo @route="space.channel.index" @models={{array space channel}} {{action "menu" "channel" "show"}}>
         <IconUsers />
       </LinkTo>
-      <a><IconPaperclip /></a><a><IconSettings /></a><a {{action "leaveChannel" this.space this.channel}} title="Leave {{this.channelname}}"><IconLogOut /></a>
+      <LinkTo @route="space.channel.shares" @models={{array space channel}} {{action "menu" "channel" "show"}}>
+        <IconPaperclip />
+      </LinkTo>
+      <LinkTo @route="space.channel.settings" @models={{array space channel}} {{action "menu" "channel" "show"}}>
+        <IconSettings />
+      </LinkTo>
+      <a {{action "leaveChannel" this.space this.channel}} title="Leave {{this.channelname}}">
+        <IconLogOut />
+      </a>
     </nav>
   </header>
 

--- a/app/components/user-list/template.hbs
+++ b/app/components/user-list/template.hbs
@@ -1,3 +1,6 @@
+{{#if this.users}}
+  <h2>{{this.users.length}} Online</h2>
+{{/if}}
 <ul>
   {{#each this.renderedUsers as |username|}}
     <li><LinkToUsername @username={{username}} /></li>

--- a/app/controllers/space/base_channel.js
+++ b/app/controllers/space/base_channel.js
@@ -33,7 +33,8 @@ export default Controller.extend({
   }),
 
   actions: {
-    menu(which, what) {
+
+    menu (which, what) {
       // Do not toggle sidebav on desktop
       if (which.match(/(global|channel)/) && window.innerWidth > 900) return;
 
@@ -142,6 +143,7 @@ export default Controller.extend({
 
       this.coms.changeTopic(this.currentSpace, channel, topic);
     }
+
   }
 
 });

--- a/app/controllers/space/base_channel.js
+++ b/app/controllers/space/base_channel.js
@@ -3,6 +3,7 @@ import { alias } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
 import { isPresent } from '@ember/utils';
 import Message from 'hyperchannel/models/message';
+import { computed } from '@ember/object';
 
 export default Controller.extend({
 
@@ -10,6 +11,7 @@ export default Controller.extend({
   application: controller(),
   space: controller(),
   coms: service(),
+  router: service(),
   storage: service('remotestorage'),
 
   currentSpace: alias('space.model'),
@@ -23,6 +25,12 @@ export default Controller.extend({
       content: message
     });
   },
+
+  sidebarClass: computed('router.currentRouteName', function(){
+    const route = this.router.currentRouteName;
+    const wideBars = ['shares', 'settings'].map(r => `space.channel.${r}`);
+    return wideBars.includes(route) ? 'sidebar-wide' : 'sidebar-normal';
+  }),
 
   actions: {
     menu(which, what) {

--- a/app/controllers/space/channel/index.js
+++ b/app/controllers/space/channel/index.js
@@ -1,0 +1,8 @@
+import Controller, { inject as controller } from '@ember/controller';
+
+export default class SpaceChannelIndexController extends Controller {
+
+  @controller space;
+  @controller('space.channel') channel;
+
+}

--- a/app/router.js
+++ b/app/router.js
@@ -9,7 +9,8 @@ export default class Router extends EmberRouter {
 Router.map(function() {
   this.route('space', { path: '/:id' }, function() {
     this.route('channel', { path: '/channel/:slug' }, function() {
-      // this.route('index', { path });
+      this.route('settings');
+      this.route('shares');
     });
     this.route('user-channel', { path: '/user/:slug' });
   });

--- a/app/router.js
+++ b/app/router.js
@@ -8,7 +8,9 @@ export default class Router extends EmberRouter {
 
 Router.map(function() {
   this.route('space', { path: '/:id' }, function() {
-    this.route('channel', { path: '/channel/:slug' });
+    this.route('channel', { path: '/channel/:slug' }, function() {
+      // this.route('index', { path });
+    });
     this.route('user-channel', { path: '/user/:slug' });
   });
 

--- a/app/routes/space/base_channel.js
+++ b/app/routes/space/base_channel.js
@@ -12,6 +12,7 @@ function focusMessageInput() {
 }
 
 export default Route.extend({
+
   coms: service(),
   userSettings: localStorageFor('user-settings'),
 
@@ -52,8 +53,11 @@ export default Route.extend({
       // Mark unread messages as read
       channel.set('unreadMessages', false);
       channel.set('unreadMentions', false);
-    }
+    },
 
+    menu (which, what) {
+      this.controller.send('menu', which, what);
+    }
   }
 
 });

--- a/app/routes/space/channel.js
+++ b/app/routes/space/channel.js
@@ -8,7 +8,7 @@ export default BaseChannel.extend({
 
   actions: {
 
-    willTransition() {
+    willTransition () {
       this.controllerFor('application')
           .set('showChannelMenu', false);
     }

--- a/app/routes/space/channel/index.js
+++ b/app/routes/space/channel/index.js
@@ -1,0 +1,4 @@
+import Route from '@ember/routing/route';
+
+export default class SpaceChannelIndexRoute extends Route {
+}

--- a/app/routes/space/channel/settings.js
+++ b/app/routes/space/channel/settings.js
@@ -1,0 +1,4 @@
+import Route from '@ember/routing/route';
+
+export default class SpaceChannelSettingsRoute extends Route {
+}

--- a/app/routes/space/channel/shares.js
+++ b/app/routes/space/channel/shares.js
@@ -1,0 +1,4 @@
+import Route from '@ember/routing/route';
+
+export default class SpaceChannelSharesRoute extends Route {
+}

--- a/app/routes/space/channel/shares.js
+++ b/app/routes/space/channel/shares.js
@@ -1,4 +1,12 @@
 import Route from '@ember/routing/route';
 
 export default class SpaceChannelSharesRoute extends Route {
+
+  activate () {
+    if (window.innerWidth < 900) {
+      this.controllerFor('application')
+          .set('showChannelMenu', true);
+    }
+  }
+
 }

--- a/app/styles/_layout.scss
+++ b/app/styles/_layout.scss
@@ -162,14 +162,14 @@ div#channel {
           }
 
           @include media("<desktop") {
-            width: $sidebarWideWidth;
+            width: 100vw;
             transform: translate3d($sidebarWideWidth, 0, 0);
           }
         }
 
         &.channel-menu-open {
           > .content {
-            transform: translate3d(-$sidebarWideWidth, 0, 0);
+            transform: translate3d(-100vw, 0, 0);
           }
 
           > aside {

--- a/app/styles/_layout.scss
+++ b/app/styles/_layout.scss
@@ -117,12 +117,11 @@ div#channel {
       }
 
       > aside {
-        section {
-          padding: 1.5rem 0;
+        @include app-column;
 
-          h2 {
-            padding: 0 1rem;
-          }
+        @include media(">desktop") {
+          flex: 0 0 $sidebarWidth;
+          transition: flex 0.4s;
         }
 
         @include media("<desktop") {
@@ -136,6 +135,14 @@ div#channel {
           transform: translate3d($sidebarWidth, 0, 0);
           transition: transform 0.4s;
         }
+
+        section {
+          padding: 1.5rem 0;
+
+          h2 {
+            padding: 0 1rem;
+          }
+        }
       }
 
       &.channel-menu-open {
@@ -147,12 +154,30 @@ div#channel {
           transform: translate3d(0, 0, 0);
         }
       }
-    }
-  }
 
-  aside {
-    flex: 0 0 $sidebarWidth;
-    @include app-column;
+      &.sidebar-wide {
+        > aside {
+          @include media(">desktop") {
+            flex: 0 0 $sidebarWideWidth;
+          }
+
+          @include media("<desktop") {
+            width: $sidebarWideWidth;
+            transform: translate3d($sidebarWideWidth, 0, 0);
+          }
+        }
+
+        &.channel-menu-open {
+          > .content {
+            transform: translate3d(-$sidebarWideWidth, 0, 0);
+          }
+
+          > aside {
+            transform: translate3d(0, 0, 0);
+          }
+        }
+      }
+    }
   }
 }
 

--- a/app/styles/_layout.scss
+++ b/app/styles/_layout.scss
@@ -117,6 +117,14 @@ div#channel {
       }
 
       > aside {
+        section {
+          padding: 1.5rem 0;
+
+          h2 {
+            padding: 0 1rem;
+          }
+        }
+
         @include media("<desktop") {
           flex: 0;
           position: absolute;

--- a/app/styles/_mixins.scss
+++ b/app/styles/_mixins.scss
@@ -9,8 +9,6 @@
   padding: 1rem;
   border: 1px solid #fff;
   border-radius: 3px;
-
-  &:first-of-type {
-    margin-top: 1.5rem;
-  }
+  background-color: rgba(255,255,255,0.9);
+  color: #333;
 }

--- a/app/styles/_mixins.scss
+++ b/app/styles/_mixins.scss
@@ -3,3 +3,14 @@
   text-transform: uppercase;
   opacity: 0.8;
 }
+
+@mixin channel_sidebar_item {
+  margin: 0.6rem 1rem;
+  padding: 1rem;
+  border: 1px solid #fff;
+  border-radius: 3px;
+
+  &:first-of-type {
+    margin-top: 1.5rem;
+  }
+}

--- a/app/styles/_mixins.scss
+++ b/app/styles/_mixins.scss
@@ -1,0 +1,5 @@
+@mixin discreet_heading {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  opacity: 0.8;
+}

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -6,6 +6,7 @@
 $modular-scale-ratio: $golden;
 $headerHeight: 42px;
 $sidebarWidth: 168px;
+$sidebarWideWidth: 320px;
 $breakpoints: (desktop: 900px);
 
 * {

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -1,5 +1,6 @@
 @import "bourbon";
 @import "colors";
+@import "mixins";
 @import "vendor/include_media";
 
 $modular-scale-ratio: $golden;

--- a/app/styles/components/channel-container.scss
+++ b/app/styles/components/channel-container.scss
@@ -147,3 +147,21 @@
   }
 
 }
+
+@include media("<desktop") {
+  .app-container:not(.channel-menu-open) {
+    #channel {
+      main {
+        header {
+          nav {
+            a, button {
+              &.active {
+                border-bottom: none;
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/app/styles/components/channel-container.scss
+++ b/app/styles/components/channel-container.scss
@@ -86,6 +86,46 @@
         .item {
           @include channel_sidebar_item;
         }
+
+        .header {
+          margin-bottom: 1.5rem;
+        }
+
+        @include media(">desktop") {
+          .header {
+            button.back {
+              display: none;
+            }
+          }
+        }
+
+        @include media("<desktop") {
+          .header {
+            display: flex;
+            padding: 0 1rem;
+            line-height: 1.4rem;
+
+            button.back {
+              display: inline-block;
+              flex: 0 0 1.4rem;
+              padding: 0;
+              color: #fff;
+              background: none;
+              border: none;
+
+              svg {
+                width: 1.4rem;
+                height: 1.4rem;
+              }
+            }
+
+            h2 {
+              display: inline-block;
+              flex: 1;
+              font-size: 1.4rem;
+            }
+          }
+        }
       }
     }
 

--- a/app/styles/components/channel-container.scss
+++ b/app/styles/components/channel-container.scss
@@ -80,6 +80,13 @@
 
     aside {
       background-color: $background-color-cyan;
+
+      // TODO move to component file when components have been created1
+      section {
+        .item {
+          @include channel_sidebar_item;
+        }
+      }
     }
 
     footer {

--- a/app/styles/components/user-list.scss
+++ b/app/styles/components/user-list.scss
@@ -1,15 +1,22 @@
 section#user-list {
   // TODO unify with other sidebar nav
   padding: 1.5em 0;
+  margin-bottom: 1.5rem;
+
+  h2 {
+    padding: 0 1rem;
+    @include discreet_heading;
+  }
 
   > ul {
+    padding-top: 0.6rem;
     list-style: none;
 
     li {
       a {
         display: block;
-        padding: 0 1em;
-        height: 1.6em;
+        padding: 0 1rem;
+        height: 1.6rem;
         line-height: 1.6em;
         overflow-wrap: unset;
         white-space: nowrap;

--- a/app/styles/components/user-list.scss
+++ b/app/styles/components/user-list.scss
@@ -1,10 +1,8 @@
 section#user-list {
   // TODO unify with other sidebar nav
-  padding: 1.5em 0;
   margin-bottom: 1.5rem;
 
   h2 {
-    padding: 0 1rem;
     @include discreet_heading;
   }
 

--- a/app/templates/space/channel.hbs
+++ b/app/templates/space/channel.hbs
@@ -5,4 +5,5 @@
                   @onMessage={{action "sendMessage"}}
                   @onCommand={{action "executeCommand"}}
                   @onLeaveChannel={{route-action "leaveChannel"}}
-                  @menu={{action "menu"}} />
+                  @menu={{action "menu"}}
+                  @sidebarClass={{this.sidebarClass}} />

--- a/app/templates/space/channel/index.hbs
+++ b/app/templates/space/channel/index.hbs
@@ -1,0 +1,1 @@
+<UserList @users={{this.channel.model.sortedUserList}} />

--- a/app/templates/space/channel/settings.hbs
+++ b/app/templates/space/channel/settings.hbs
@@ -1,5 +1,11 @@
 <section id="channel-settings" class="main">
-  <h2>Settings</h2>
+  <div class="header">
+    <button type="button" class="back"
+            {{on "click" (route-action "menu" "channel" "hide")}}>
+      <IconArrowLeft />
+    </button>
+    <h2>Settings</h2>
+  </div>
 
   <div class="item">setting</div>
   <div class="item">setting</div>

--- a/app/templates/space/channel/settings.hbs
+++ b/app/templates/space/channel/settings.hbs
@@ -1,0 +1,3 @@
+<section id="channel-settings" class="main">
+  <h2>Settings</h2>
+</section>

--- a/app/templates/space/channel/settings.hbs
+++ b/app/templates/space/channel/settings.hbs
@@ -1,3 +1,7 @@
 <section id="channel-settings" class="main">
   <h2>Settings</h2>
+
+  <div class="item">setting</div>
+  <div class="item">setting</div>
+  <div class="item">setting</div>
 </section>

--- a/app/templates/space/channel/shares.hbs
+++ b/app/templates/space/channel/shares.hbs
@@ -1,5 +1,11 @@
 <section id="channel-shared-items" class="main">
-  <h2>Shared items</h2>
+  <div class="header">
+    <button type="button" class="back"
+            {{on "click" (route-action "menu" "channel" "hide")}}>
+      <IconArrowLeft />
+    </button>
+    <h2>Shared items</h2>
+  </div>
 
   <div class="item">item</div>
   <div class="item">item</div>

--- a/app/templates/space/channel/shares.hbs
+++ b/app/templates/space/channel/shares.hbs
@@ -1,3 +1,8 @@
 <section id="channel-shared-items" class="main">
   <h2>Shared items</h2>
+
+  <div class="item">item</div>
+  <div class="item">item</div>
+  <div class="item">item</div>
+  <div class="item">item</div>
 </section>

--- a/app/templates/space/channel/shares.hbs
+++ b/app/templates/space/channel/shares.hbs
@@ -1,0 +1,3 @@
+<section id="channel-shared-items" class="main">
+  <h2>Shared items</h2>
+</section>

--- a/tests/unit/controllers/space/channel/index-test.js
+++ b/tests/unit/controllers/space/channel/index-test.js
@@ -1,0 +1,12 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Controller | space/channel/index', function(hooks) {
+  setupTest(hooks);
+
+  // Replace this with your real tests.
+  test('it exists', function(assert) {
+    let controller = this.owner.lookup('controller:space/channel/index');
+    assert.ok(controller);
+  });
+});

--- a/tests/unit/routes/space/channel/index-test.js
+++ b/tests/unit/routes/space/channel/index-test.js
@@ -1,0 +1,11 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Route | space/channel/index', function(hooks) {
+  setupTest(hooks);
+
+  test('it exists', function(assert) {
+    let route = this.owner.lookup('route:space/channel/index');
+    assert.ok(route);
+  });
+});

--- a/tests/unit/routes/space/channel/settings-test.js
+++ b/tests/unit/routes/space/channel/settings-test.js
@@ -1,0 +1,11 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Route | space/channel/settings', function(hooks) {
+  setupTest(hooks);
+
+  test('it exists', function(assert) {
+    let route = this.owner.lookup('route:space/channel/settings');
+    assert.ok(route);
+  });
+});

--- a/tests/unit/routes/space/channel/shares-test.js
+++ b/tests/unit/routes/space/channel/shares-test.js
@@ -1,0 +1,11 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Route | space/channel/shares', function(hooks) {
+  setupTest(hooks);
+
+  test('it exists', function(assert) {
+    let route = this.owner.lookup('route:space/channel/shares');
+    assert.ok(route);
+  });
+});


### PR DESCRIPTION
Makes channel sidebar content routable via channel subroutes, and adds header styles and dummy content. Also introduces wide sidebars for tabs with more content.

The sidebars work slightly different on desktop and mobile, as they're optimized for the available screen real estate.

### Desktop

![hyperchannel-channel-sidebar-desktop](https://user-images.githubusercontent.com/842/73222975-9b6cf200-4132-11ea-92cd-00f3edcb83ba.gif)

### Mobile

![hyperchannel-channel-sidebar-mobile](https://user-images.githubusercontent.com/842/73223005-ae7fc200-4132-11ea-81b8-cb7c79071b9c.gif)


