### PR TITLE
Improve channel list/nav for XMPP spaces

### DIFF
--- a/app/components/channel-nav/template.hbs
+++ b/app/components/channel-nav/template.hbs
@@ -2,7 +2,15 @@
     {{will-destroy this.unbindKeyboardShortcuts}}>
   {{#each @spaces as |space|}}
     <li>
-      <h2><LinkTo @route="space" @model={{space}}>{{space.name}}</LinkTo></h2>
+      <h2>
+        <LinkTo @route="space" @model={{space}}>
+          {{#if (eq space.protocol "XMPP")}}
+            {{space.server.username}}
+          {{else}}
+            {{space.name}}
+          {{/if}}
+        </LinkTo>
+      </h2>
       <ul>
         {{#each space.sortedChannels as |channel|}}
           <li class="{{if channel.connected "connected" "disconnected"}} {{channel.unreadMessagesClass}} {{if channel.visible "active" ""}}">

--- a/app/components/channel-nav/template.hbs
+++ b/app/components/channel-nav/template.hbs
@@ -17,7 +17,7 @@
             {{#if channel.isUserChannel}}
               <LinkTo @route="space.user-channel" @models={{array space channel}}>{{channel.name}}</LinkTo>
             {{else}}
-              <LinkTo @route="space.channel" @models={{array space channel}}>{{channel.name}}</LinkTo>
+            <LinkTo @route="space.channel" @models={{array space channel}}>#&thinsp;{{channel.shortName}}</LinkTo>
             {{/if}}
             <a {{on "click" (fn @onLeaveChannel space channel)}} class="leave-channel" title="Leave {{channel.name}}">x</a>
           </li>

--- a/app/components/channel-nav/template.hbs
+++ b/app/components/channel-nav/template.hbs
@@ -1,31 +1,51 @@
 <ul {{did-insert this.bindKeyboardShortcuts}}
     {{will-destroy this.unbindKeyboardShortcuts}}>
   {{#each @spaces as |space|}}
-    <li>
-      <h2>
-        <LinkTo @route="space" @model={{space}}>
-          {{#if (eq space.protocol "XMPP")}}
-            {{space.server.username}}
-          {{else}}
-            {{space.name}}
-          {{/if}}
-        </LinkTo>
-      </h2>
-      <ul>
-        {{#each space.sortedChannels as |channel|}}
-          <li class="{{if channel.connected "connected" "disconnected"}} {{channel.unreadMessagesClass}} {{if channel.visible "active" ""}}">
-            {{#if channel.isUserChannel}}
-              <LinkTo @route="space.user-channel" @models={{array space channel}}>{{channel.name}}</LinkTo>
-            {{else}}
-            <LinkTo @route="space.channel" @models={{array space channel}}>#&thinsp;{{channel.shortName}}</LinkTo>
-            {{/if}}
-            <a {{on "click" (fn @onLeaveChannel space channel)}} class="leave-channel" title="Leave {{channel.name}}">x</a>
+    {{#if (eq space.protocol "IRC")}}
+      <li>
+        <h2>
+          <LinkTo @route="space" @model={{space}}>{{space.name}}</LinkTo>
+        </h2>
+        <ul>
+          {{#each space.sortedChannels as |channel|}}
+            <li class="{{if channel.connected "connected" "disconnected"}} {{channel.unreadMessagesClass}} {{if channel.visible "active" ""}}">
+              {{#if channel.isUserChannel}}
+                <LinkTo @route="space.user-channel" @models={{array space channel}}>{{channel.name}}</LinkTo>
+              {{else}}
+                <LinkTo @route="space.channel" @models={{array space channel}}>#&thinsp;{{channel.shortName}}</LinkTo>
+              {{/if}}
+              <a {{on "click" (fn @onLeaveChannel space channel)}} class="leave-channel" title="Leave {{channel.name}}">x</a>
+            </li>
+          {{/each}}
+          <li>
+            <a {{on "click" (fn this.joinChannel space)}} class="join-channel" role="button">+</a>
           </li>
+        </ul>
+      </li>
+    {{/if}}
+
+    {{#if (eq space.protocol "XMPP")}}
+      <li>
+        <h2>
+          <LinkTo @route="space" @model={{space}}>{{space.server.username}}</LinkTo>
+        </h2>
+        {{#each space.groupedChannelsByMUCDomain as |subspace|}}
+          <h3>{{subspace.domain}}</h3>
+          <ul>
+            {{#each subspace.channels as |channel|}}
+              <li class="{{if channel.connected "connected" "disconnected"}} {{channel.unreadMessagesClass}} {{if channel.visible "active" ""}}">
+                {{#if channel.isUserChannel}}
+                  <LinkTo @route="space.user-channel" @models={{array space channel}}>{{channel.name}}</LinkTo>
+                {{else}}
+                  <LinkTo @route="space.channel" @models={{array space channel}}>#&thinsp;{{channel.shortName}}</LinkTo>
+                {{/if}}
+                <a {{on "click" (fn @onLeaveChannel space channel)}} class="leave-channel" title="Leave {{channel.name}}">x</a>
+              </li>
+            {{/each}}
+          </ul>
         {{/each}}
-        <li>
-          <a {{on "click" (fn this.joinChannel space)}} class="join-channel" role="button">+</a>
-        </li>
-      </ul>
-    </li>
+        <a {{on "click" (fn this.joinChannel space)}} class="join-channel" role="button">+</a>
+      </li>
+    {{/if}}
   {{/each}}
 </ul>

--- a/app/models/base_channel.js
+++ b/app/models/base_channel.js
@@ -49,6 +49,15 @@ export default class BaseChannel {
     }
   }
 
+  get mucDomain () {
+    switch (this.space.protocol) {
+      case 'XMPP':
+        return this.name.match(/@(.+)$/)[1];
+      default:
+        return null;
+    }
+  }
+
   get unreadMessagesClass () {
     if (this.visible || !this.unreadMessages) {
       return null;

--- a/app/models/base_channel.js
+++ b/app/models/base_channel.js
@@ -8,7 +8,8 @@ import moment from 'moment';
 export default class BaseChannel {
 
   @tracked space = null;
-  @tracked name = '';
+  @tracked name = ''; // e.g. kosmos-dev@kosmos.chat
+  @tracked displayName = ''; // e.g. Kosmos Dev
   @tracked userList = A([]);
   @tracked messages = A([]);
   @tracked connected = false;
@@ -35,6 +36,17 @@ export default class BaseChannel {
     // This could be based on server type in the future. E.g. IRC would be
     // server URL, while Campfire would be another id.
     return this.name.replace(/#/g,'');
+  }
+
+  get shortName () {
+    switch (this.space.protocol) {
+      case 'IRC':
+        return this.name.replace(/#/g,'');
+      case 'XMPP':
+        return this.name.match(/^(.+)@/)[1];
+      default:
+        return this.name;
+    }
   }
 
   get unreadMessagesClass () {

--- a/app/models/space.js
+++ b/app/models/space.js
@@ -72,6 +72,20 @@ export default class Space {
     return this.channels.findBy('visible', true);
   }
 
+  @computed('channels.@each.mucDomain')
+  get mucDomains () {
+    return this.channels.mapBy('mucDomain').uniq().sort();
+  }
+
+  get groupedChannelsByMUCDomain () {
+    return this.mucDomains.map(domain => {
+      return {
+        domain: domain,
+        channels: this.channels.filterBy('mucDomain', domain).sortBy('name')
+      }
+    });
+  }
+
   updateUsername (username) {
     // keep track of old name for later reference
     this.previousSockethubPersonIds.pushObject(this.sockethubPersonId);

--- a/app/styles/_layout.scss
+++ b/app/styles/_layout.scss
@@ -35,6 +35,8 @@
 }
 
 #global {
+  overflow: hidden;
+
   header {
     &#sitename {
       padding: 0 1em;

--- a/app/styles/components/channel-nav.scss
+++ b/app/styles/components/channel-nav.scss
@@ -20,7 +20,7 @@ nav#channels {
       margin-bottom: 1.6em;
 
       > ul {
-        padding: 0.6em 0 0 0;
+        padding: 0 0 0 0;
         list-style: none;
 
         li {
@@ -87,5 +87,23 @@ nav#channels {
         color: #fff;
       }
     }
+  }
+
+  h2 {
+    margin-bottom: 0.6rem;
+  }
+
+  h3 {
+    display: block;
+    height: 1.6rem;
+    line-height: 1.6rem;
+    padding: 0 1rem;
+    margin: 0.4rem 0 0.2rem 0;
+    font-size: 0.9rem;
+    opacity: 0.8;
+  }
+
+  h2 + h3 {
+    margin-top: -0.2rem;
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15567,6 +15567,89 @@
         "ember-cli-babel": "^7.1.2"
       }
     },
+    "ember-truth-helpers": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ember-truth-helpers/-/ember-truth-helpers-2.1.0.tgz",
+      "integrity": "sha512-BQlU8aTNl1XHKTYZ243r66yqtR9JU7XKWQcmMA+vkqfkE/c9WWQ9hQZM8YABihCmbyxzzZsngvldokmeX5GhAw==",
+      "dev": true,
+      "requires": {
+        "ember-cli-babel": "^6.6.0"
+      },
+      "dependencies": {
+        "broccoli-debug": {
+          "version": "0.6.5",
+          "resolved": "https://registry.npmjs.org/broccoli-debug/-/broccoli-debug-0.6.5.tgz",
+          "integrity": "sha512-RIVjHvNar9EMCLDW/FggxFRXqpjhncM/3qq87bn/y+/zR9tqEkHvTqbyOc4QnB97NO2m6342w4wGkemkaeOuWg==",
+          "dev": true,
+          "requires": {
+            "broccoli-plugin": "^1.2.1",
+            "fs-tree-diff": "^0.5.2",
+            "heimdalljs": "^0.2.1",
+            "heimdalljs-logger": "^0.1.7",
+            "symlink-or-copy": "^1.1.8",
+            "tree-sync": "^1.2.2"
+          }
+        },
+        "broccoli-funnel": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz",
+          "integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
+          "dev": true,
+          "requires": {
+            "array-equal": "^1.0.0",
+            "blank-object": "^1.0.1",
+            "broccoli-plugin": "^1.3.0",
+            "debug": "^2.2.0",
+            "fast-ordered-set": "^1.0.0",
+            "fs-tree-diff": "^0.5.3",
+            "heimdalljs": "^0.2.0",
+            "minimatch": "^3.0.0",
+            "mkdirp": "^0.5.0",
+            "path-posix": "^1.0.0",
+            "rimraf": "^2.4.3",
+            "symlink-or-copy": "^1.0.0",
+            "walk-sync": "^0.3.1"
+          }
+        },
+        "ember-cli-babel": {
+          "version": "6.18.0",
+          "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-6.18.0.tgz",
+          "integrity": "sha512-7ceC8joNYxY2wES16iIBlbPSxwKDBhYwC8drU3ZEvuPDMwVv1KzxCNu1fvxyFEBWhwaRNTUxSCsEVoTd9nosGA==",
+          "dev": true,
+          "requires": {
+            "amd-name-resolver": "1.2.0",
+            "babel-plugin-debug-macros": "^0.2.0-beta.6",
+            "babel-plugin-ember-modules-api-polyfill": "^2.6.0",
+            "babel-plugin-transform-es2015-modules-amd": "^6.24.0",
+            "babel-polyfill": "^6.26.0",
+            "babel-preset-env": "^1.7.0",
+            "broccoli-babel-transpiler": "^6.5.0",
+            "broccoli-debug": "^0.6.4",
+            "broccoli-funnel": "^2.0.0",
+            "broccoli-source": "^1.1.0",
+            "clone": "^2.0.0",
+            "ember-cli-version-checker": "^2.1.2",
+            "semver": "^5.5.0"
+          }
+        },
+        "ember-cli-version-checker": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz",
+          "integrity": "sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==",
+          "dev": true,
+          "requires": {
+            "resolve": "^1.3.3",
+            "semver": "^5.3.0"
+          }
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
+      }
+    },
     "ember-weakmap": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/ember-weakmap/-/ember-weakmap-3.3.2.tgz",

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "ember-sinon-qunit": "^3.4.0",
     "ember-source": "~3.17.0",
     "ember-template-lint": "^2.4.0",
+    "ember-truth-helpers": "^2.1.0",
     "eslint": "^6.8.0",
     "eslint-plugin-ember": "^7.10.1",
     "eslint-plugin-node": "^11.0.0",

--- a/tests/unit/models/channel-test.js
+++ b/tests/unit/models/channel-test.js
@@ -1,5 +1,6 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
+import Space from 'hyperchannel/models/space';
 import Channel from 'hyperchannel/models/channel';
 
 module('Unit | Model | channel', function(hooks) {
@@ -18,5 +19,20 @@ module('Unit | Model | channel', function(hooks) {
 
     assert.equal(channel.formattedTopic.toString(), 'never gonna &lt;marquee&gt;give you up&lt;/marquee&gt;');
   });
+
+  test('#shortName for IRC returns name without hash', function(assert) {
+    const space = new Space({ protocol: 'IRC' });
+    const channel = new Channel({ space: space, name: '#kosmos-dev' });
+
+    assert.equal(channel.shortName, 'kosmos-dev');
+  });
+
+  test('#shortName for XMPP returns name without MUC domain', function(assert) {
+    const space = new Space({ protocol: 'XMPP' });
+    const channel = new Channel({ space: space, name: 'kosmos-dev@kosmos.chat' });
+
+    assert.equal(channel.shortName, 'kosmos-dev');
+  });
+
 });
 

--- a/tests/unit/models/channel-test.js
+++ b/tests/unit/models/channel-test.js
@@ -5,16 +5,6 @@ import Channel from 'hyperchannel/models/channel';
 module('Unit | Model | channel', function(hooks) {
   setupTest(hooks);
 
-  test('it exists', function(assert) {
-    const model = new Channel();
-    assert.ok(!!model);
-  });
-
-
-  //
-  // formattedTopic
-  //
-
   test('#formattedTopic turns URLs into links', function(assert) {
     const channel = new Channel();
     channel.topic = 'visit kosmos.org for more info';

--- a/tests/unit/models/channel-test.js
+++ b/tests/unit/models/channel-test.js
@@ -34,5 +34,14 @@ module('Unit | Model | channel', function(hooks) {
     assert.equal(channel.shortName, 'kosmos-dev');
   });
 
+  test('#mucDomain', function(assert) {
+    let space = new Space({ protocol: 'XMPP' });
+    let channel = new Channel({ space: space, name: 'kosmos-dev@kosmos.chat' });
+    assert.equal(channel.mucDomain, 'kosmos.chat', 'returns the MUC domain for XMPP channels');
+
+    space = new Space({ protocol: 'IRC' });
+    channel = new Channel({ space: space, name: '#kosmos-dev' });
+    assert.equal(channel.mucDomain, null, 'returns null for other channels');
+  });
 });
 

--- a/tests/unit/models/space-test.js
+++ b/tests/unit/models/space-test.js
@@ -21,6 +21,41 @@ module('Unit | Model | space', function(hooks) {
     assert.deepEqual(sortedChannels.mapBy('name'), ['canoa', 'dominica', 'flores', 'lamu', 'phu quoc']);
   });
 
+  test('#mucDomains returns unique MUC domains of all channels', function(assert) {
+    const space = new Space({
+      protocol: 'XMPP',
+      channels: [
+        new Channel({name: 'kosmos@kosmos.chat'}),
+        new Channel({name: 'kosmos-dev@kosmos.chat'}),
+        new Channel({name: 'kosmos-random@kosmos.chat'}),
+        new Channel({name: 'chat@dino.im'}),
+      ]
+    });
+    space.channels.setEach('space', space);
+
+    assert.deepEqual(space.mucDomains, ['dino.im', 'kosmos.chat']);
+  });
+
+  test('#groupedChannelsByMUCDomain returns channels grouped by MUC domain', function(assert) {
+    const space = new Space({
+      protocol: 'XMPP',
+      channels: [
+        new Channel({name: 'kosmos@kosmos.chat'}),
+        new Channel({name: 'kosmos-random@kosmos.chat'}),
+        new Channel({name: 'kosmos-dev@kosmos.chat'}),
+        new Channel({name: 'chat@dino.im'}),
+      ]
+    });
+    space.channels.setEach('space', space);
+    const channels = space.groupedChannelsByMUCDomain;
+
+    assert.deepEqual(channels[0].domain, 'dino.im');
+    assert.deepEqual(channels[0].channels.length, 1);
+    assert.deepEqual(channels[1].domain, 'kosmos.chat');
+    assert.deepEqual(channels[1].channels.length, 3);
+    assert.deepEqual(channels[1].channels[0].name, 'kosmos-dev@kosmos.chat');
+  });
+
   test('#loggedChannels returns list of channels when space is Freenode', function(assert) {
     const space = new Space({ name: 'Freenode' });
 
@@ -48,6 +83,7 @@ module('Unit | Model | space', function(hooks) {
     assert.deepEqual(space.channelNames, ['#kosmos', '#kosmos-dev', '#remotestorage']);
   });
 
+
   test('#sockethubChannelIds returns IDs of the channels', function(assert) {
     const space = new Space();
 
@@ -59,4 +95,6 @@ module('Unit | Model | space', function(hooks) {
 
     assert.deepEqual(space.sockethubChannelIds, ['freenode.net/#kosmos', 'freenode.net/#kosmos-dev', 'freenode.net/#remotestorage']);
   });
+
+
 });


### PR DESCRIPTION
* Show user address instead of space name
* Group channels by MUC domain
* Show short channel name instead of full JID. Add a hash so they look familiar (like IRC and Slack channels)

![Screenshot from 2020-04-01 20-06-36](https://user-images.githubusercontent.com/842/78200776-482a5f00-7455-11ea-9b03-50cbdc442cc9.png)
