### PR TITLE
Replace Ember observers with render modifiers

### DIFF
--- a/app/components/channel-container/component.js
+++ b/app/components/channel-container/component.js
@@ -4,7 +4,7 @@ import { later, scheduleOnce } from '@ember/runloop';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { task } from 'ember-concurrency';
-import { action, observer } from '@ember/object';
+import { action } from '@ember/object';
 
 function scrollToBottom () {
   let elem = document.getElementById('channel-content');
@@ -32,18 +32,20 @@ export default class ChannelContainerComponent extends Component {
     }
   }
 
-  channelChanged = observer('channel', function () {
+  @action
+  channelChanged () {
     this.renderedMessagesCount = this.renderedMessagesAddendumAmount;
     this.partialRenderingEnabled = true;
     this.automaticScrollingEnabled = true;
-    later(this, () => this.send('menu', 'global', 'hide'), 500);
-  });
+    later(this, () => this.menu('global', 'hide'), 500);
+  }
 
-  messagesUpdated = observer('renderedMessages.[]', function () {
+  @action
+  messagesUpdated () {
     if (this.automaticScrollingEnabled) {
       scheduleOnce('afterRender', scrollToBottom);
     }
-  });
+  }
 
   @action
   scheduleOnAfterRender () {

--- a/app/components/channel-container/template.hbs
+++ b/app/components/channel-container/template.hbs
@@ -1,4 +1,5 @@
-<div id="channel" {{did-insert this.scheduleOnAfterRender}}>
+<div id="channel" {{did-insert this.scheduleOnAfterRender}}
+                  {{did-update this.channelChanged @channel}}>
   <main>
     <header id="channel-header">
       <h2 id="channel-name"
@@ -42,7 +43,7 @@
                                  @onIntersect={{fn this.increaseRenderedMessagesCount}} />
             </li>
             {{#each this.renderedMessages as |message|}}
-              <li>
+              <li {{did-insert this.messagesUpdated}}>
                 {{component message.type message=message
                             onUsernameClick=(fn this.addUsernameMentionToMessage)}}
               </li>

--- a/app/components/scrolling-observer/component.js
+++ b/app/components/scrolling-observer/component.js
@@ -1,11 +1,11 @@
+/* eslint ember/no-observers: "off" */
 import Component from '@glimmer/component';
 import { scheduleOnce } from '@ember/runloop';
-import { action, observer } from '@ember/object';
+import { action } from '@ember/object';
 
 export default class ScrollingObserverComponent extends Component {
 
   observer = null;
-  element = null;
 
   get enabled () {
     if (typeof this.args.enabled === 'undefined') {
@@ -70,8 +70,8 @@ export default class ScrollingObserverComponent extends Component {
             scheduleOnce('afterRender', this, 'retriggerObservation', observer, entry.target);
           }
         } else {
-          if (this.onDiverge) {
-            this.onDiverge();
+          if (this.args.onDiverge) {
+            this.args.onDiverge();
           }
         }
       });
@@ -80,22 +80,23 @@ export default class ScrollingObserverComponent extends Component {
     observer.observe(element);
 
     this.observer = observer;
-    this.element = element;
   }
 
-  rootMarginChanged = observer('rootMargin', function () {
+  @action
+  rootMarginChanged (element) {
     if (this.enabled && this.observer) {
       this.observer.disconnect();
-      this.createIntersectionObserver();
+      this.createIntersectionObserver(element);
     }
-  });
+  }
 
-  enabledChanged = observer('enabled', function () {
+  @action
+  enabledChanged  (element) {
     if (this.enabled) {
-      this.observer.observe(this.element);
+      this.observer.observe(element);
     } else {
       this.observer.disconnect();
     }
-  });
+  }
 
 }

--- a/app/components/scrolling-observer/template.hbs
+++ b/app/components/scrolling-observer/template.hbs
@@ -1,1 +1,4 @@
-<div {{did-insert this.createObserver}} {{will-destroy this.disconnectObserver}}></div>
+<div {{did-insert this.createObserver}}
+     {{will-destroy this.disconnectObserver}}
+     {{did-update this.enabledChanged @enabled}}
+     {{did-update this.rootMarginChanged @rootMargin}}></div>

--- a/app/components/user-list/component.js
+++ b/app/components/user-list/component.js
@@ -1,6 +1,6 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import { action, observer } from '@ember/object';
+import { action } from '@ember/object';
 import { scheduleOnce } from '@ember/runloop';
 
 export default class UserListComponent extends Component {
@@ -17,16 +17,17 @@ export default class UserListComponent extends Component {
     }
   }
 
+  scrollToTop (element) {
+    element.scrollTop = 0;
+  }
+
   // called when changing list of users (i.e. when switching channels)
-  usersChanged = observer('users', function () {
+  @action
+  usersChanged (element) {
     this.renderedUsersCount = this.renderedUsersAddendumAmount;
     this.partialRenderingEnabled = true;
 
-    scheduleOnce('afterRender', this, this.scrollToTop);
-  })
-
-  scrollToTop () {
-    this.element.scrollTop = 0;
+    scheduleOnce('afterRender', this, this.scrollToTop, element);
   }
 
   @action

--- a/app/components/user-list/template.hbs
+++ b/app/components/user-list/template.hbs
@@ -1,4 +1,4 @@
-<section id="user-list" class="main">
+<section id="user-list" class="main" {{did-update this.usersChanged @users}}>
   {{#if @users}}
     <h2>{{@users.length}} Online</h2>
   {{/if}}


### PR DESCRIPTION
Fixes #202

After the Octane upgrade, all observers were broken. Replacing them with render modifiers fixed the issues and also removed the last remaining deprecation warnings.

The ScrollingObserver component doesn't use any Ember observers anymore, but still contains the word "observer". So I had to add an ESLint config line to ignore the "ember/no-observers" rule to the component.js file.