### PR TITLE
Fix date-headline markup

### DIFF
--- a/app/components/date-headline/template.hbs
+++ b/app/components/date-headline/template.hbs
@@ -1,1 +1,3 @@
-<h3 class="date-headline">{{this.headline}}</h3>
+<div class="date-headline">
+  <h3>{{this.headline}}</h3>
+</div>


### PR DESCRIPTION
Fixes #207

The markup structure was mixed up when migrating the component to a Glimmer component.