### PR TITLE
Fix getChannel() function

### DIFF
--- a/app/services/coms.js
+++ b/app/services/coms.js
@@ -213,10 +213,10 @@ export default class ComsService extends Service {
   }
 
   /**
-   * @param {String} personId
    * @param {String} channelId
+   * @param {String} personId
    */
-  getChannel (personId, channelId) {
+  getChannel (channelId, personId) {
     const space = this.spaces.findBy('sockethubPersonId', personId);
     if (isEmpty(space)) {
       console.warn('Could not find space by sockethubPersonId', personId);


### PR DESCRIPTION
The `observe` objects have the actor being the person and the target being the channel to observe. No idea how this worked for IRC before, because it was failing for IRC now, while XMPP [had the properties switched](https://github.com/sockethub/sockethub/pull/374) in its messages.