### PR TITLE
Refactor spaces to accounts/channels for IRC

### DIFF
--- a/app/components/add-chat-account-irc/component.js
+++ b/app/components/add-chat-account-irc/component.js
@@ -14,6 +14,7 @@ export default class AddChatAccountIrcComponent extends Component {
   @tracked hostname = 'irc.libera.chat';
   @tracked port = '6697';
   @tracked nickname;
+  // TODO Implement authenticated connect using SASL
   // @tracked username;
   // @tracked password;
   // @tracked serverPassword;
@@ -25,54 +26,41 @@ export default class AddChatAccountIrcComponent extends Component {
     return this.nickname;
   }
 
-  async handleConnectFailure (message) {
-    console.debug('handleConnectFailure called') // TODO remove
-    if (message.context !== 'irc') return;
-    debugger;
-  }
+  // TODO Implement once available
+  // async handleConnectFailure (message) {
+  //   console.debug('handleConnectFailure called with', message);
+  // }
 
-  async handleConnectMessage (message) {
-    console.debug('handleConnectMessage called') // TODO remove
-    if (message.context !== 'irc') return;
-    debugger;
-  }
+  // TODO Implement once available
+  // async handleConnectMessage (message) {
+  //   console.debug('handleConnectMessage called with', message);
+  //
+  //   if (message['@type'] === 'error' &&
+  //       message.object.condition === 'not-authorized'
+  //       && TODO message.actor['@id'] === actor */) {
+  //     this.connectError = {
+  //       title: 'Account connection failed',
+  //       content: message.object.content
+  //     }
+  //     this.xmpp.sockethub.socket.offAny();
+  //   }
+  // }
 
-  async handleConnectCompleted (message) {
-    console.debug('handleConnectComplete called') // TODO remove
-    if (message.context !== 'irc') return;
-    // if (this.finishedSetup) {
-    //   // TODO remove when double events fixed
-    //   console.debug('Account setup already finished, nothing to do')
-    //   return;
-    // }
+  // TODO Implement once available
+  // async handleConnectCompleted (message) {
+  //   console.debug('handleConnectComplete called with', message);
+  //
+  //   if (message['@type'] === 'connect' &&
+  //       message.actor['@id'] === this.userAddress) {
+  //     // Connected successfully
+  //     const account = await this.addAccount();
+  //     this.addDefaultChannels(account);
+  //     // this.finishedSetup = true;
+  //     // this.router.transitionTo('channel', /* welcome channel */);
+  //   }
+  // }
 
-        // && !['message', 'completed'].includes(eventName)) { return; }
-
-    // if (message['@type'] === 'error' &&
-    //     message.object.condition === 'not-authorized'
-    //     /* && TODO message.actor['@id'] === actor */) {
-    //   this.connectError = {
-    //     title: 'Account connection failed',
-    //     content: message.object.content
-    //   }
-    //   this.xmpp.sockethub.socket.offAny();
-    // }
-
-    debugger;
-
-    if (message['@type'] === 'connect' &&
-        message.actor['@id'] === this.userAddress) {
-      // Connected successfully
-
-      const account = await this.addAccount();
-      this.addDefaultChannels(account);
-      // this.finishedSetup = true;
-
-      // this.router.transitionTo('channel', /* welcome channel */);
-    }
-  }
-
-  async instantiateAccount () {
+  instantiateAccount () {
     return new IrcAccount({
       server: {
         hostname: this.hostname,
@@ -103,16 +91,23 @@ export default class AddChatAccountIrcComponent extends Component {
   }
 
   @action
-  submitForm (e) {
+  async submitForm (e) {
     e.preventDefault();
     this.connectError = null;
 
-    this.irc.sockethub.socket.on('failure', this.handleConnectFailure.bind(this));
-    this.irc.sockethub.socket.on('message', this.handleConnectMessage.bind(this));
-    this.irc.sockethub.socket.on('completed', this.handleConnectCompleted.bind(this));
+    this.irc.sockethub.socket.onAny(() => console.debug(...arguments));
 
-    const account = this.instantiateAccount();
+    // TODO Handle connect status once implemented in Sockethub
+    // this.irc.sockethub.socket.on('failure', this.handleConnectFailure.bind(this));
+    // this.irc.sockethub.socket.on('message', this.handleConnectMessage.bind(this));
+    // this.irc.sockethub.socket.on('completed', this.handleConnectCompleted.bind(this));
+
+    const account = await this.createAccount();
     this.irc.connect(account);
+
+    // TODO Move to connect-completed handler once available; let user change channels to join
+    this.addDefaultChannels(account);
+    this.router.transitionTo('channel', this.coms.channels.firstObject);
   }
 
 }

--- a/app/components/add-chat-account-irc/component.js
+++ b/app/components/add-chat-account-irc/component.js
@@ -1,10 +1,118 @@
 import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
+import IrcAccount from 'hyperchannel/models/account/irc';
 
 export default class AddChatAccountIrcComponent extends Component {
 
+  @service router;
   @service coms;
   @service('sockethub-irc') irc;
   @service('remotestorage') storage;
+
+  @tracked hostname = 'irc.libera.chat';
+  @tracked port = '6697';
+  @tracked nickname;
+  // @tracked username;
+  // @tracked password;
+  // @tracked serverPassword;
+  @tracked useTls = true;
+  @tracked connectError = null;
+  @tracked showCredentialFields = false;
+
+  get username () {
+    return this.nickname;
+  }
+
+  async handleConnectFailure (message) {
+    console.debug('handleConnectFailure called') // TODO remove
+    if (message.context !== 'irc') return;
+    debugger;
+  }
+
+  async handleConnectMessage (message) {
+    console.debug('handleConnectMessage called') // TODO remove
+    if (message.context !== 'irc') return;
+    debugger;
+  }
+
+  async handleConnectCompleted (message) {
+    console.debug('handleConnectComplete called') // TODO remove
+    if (message.context !== 'irc') return;
+    // if (this.finishedSetup) {
+    //   // TODO remove when double events fixed
+    //   console.debug('Account setup already finished, nothing to do')
+    //   return;
+    // }
+
+        // && !['message', 'completed'].includes(eventName)) { return; }
+
+    // if (message['@type'] === 'error' &&
+    //     message.object.condition === 'not-authorized'
+    //     /* && TODO message.actor['@id'] === actor */) {
+    //   this.connectError = {
+    //     title: 'Account connection failed',
+    //     content: message.object.content
+    //   }
+    //   this.xmpp.sockethub.socket.offAny();
+    // }
+
+    debugger;
+
+    if (message['@type'] === 'connect' &&
+        message.actor['@id'] === this.userAddress) {
+      // Connected successfully
+
+      const account = await this.addAccount();
+      this.addDefaultChannels(account);
+      // this.finishedSetup = true;
+
+      // this.router.transitionTo('channel', /* welcome channel */);
+    }
+  }
+
+  async instantiateAccount () {
+    return new IrcAccount({
+      server: {
+        hostname: this.hostname,
+        port: this.port,
+        secure: this.useTls
+      },
+      nickname: this.nickname,
+      // username: this.username,
+      // password: this.password,
+    });
+  }
+
+  async createAccount () {
+    const account = this.instantiateAccount();
+    this.coms.accounts.pushObject(account);
+    return this.storage.saveAccount(account).then(() => account);
+  }
+
+  addDefaultChannels (account) {
+    const defaultChannels = [
+      '#kosmos',
+      '#kosmos-random'
+    ];
+
+    defaultChannels.forEach(name => {
+      this.coms.createChannel(account, name, { saveConfig: true })
+    });
+  }
+
+  @action
+  submitForm (e) {
+    e.preventDefault();
+    this.connectError = null;
+
+    this.irc.sockethub.socket.on('failure', this.handleConnectFailure.bind(this));
+    this.irc.sockethub.socket.on('message', this.handleConnectMessage.bind(this));
+    this.irc.sockethub.socket.on('completed', this.handleConnectCompleted.bind(this));
+
+    const account = this.instantiateAccount();
+    this.irc.connect(account);
+  }
 
 }

--- a/app/components/add-chat-account-irc/template.hbs
+++ b/app/components/add-chat-account-irc/template.hbs
@@ -1,1 +1,43 @@
-<em>TODO: add-chat-account-irc component</em>
+<form {{on "submit" this.submitForm}}>
+  <div class="grid grid-cols-1 gap-2 sm:grid-cols-10 sm:gap-4 sm:items-center mb-8">
+    <label for="hostname" class="sm:col-span-3">
+      Host
+    </label>
+    <div class="mb-4 sm:mb-0 sm:col-span-7 flex justify-center items-center">
+      <Input id="hostname" @type="text" @value={{this.hostname}} name="hostname"
+             placeholder="Hostname" required class="flex-grow min-w-0" />
+      <span class="flex-0 mx-1 text-xl">:</span>
+      <Input id="port" @type="text" @value={{this.port}} name="port"
+             placeholder="Port" required class="flex-shrink w-40 min-w-0" />
+    </div>
+    <label for="nickname" class="sm:col-span-3">
+      Nickname
+    </label>
+    <Input id="nickname" @type="text" @value={{this.nickname}} name="nickname"
+           required class="sm:col-span-7" />
+
+    {{#if this.showCredentialFields}}
+      <label for="username" class="sm:col-span-3">
+        Username
+      </label>
+      <Input id="username" @type="text" @value={{this.username}} name="nickname"
+             class="sm:col-span-7" />
+      <label for="password" class="sm:col-span-3">
+        Password
+      </label>
+      <Input id="password" @type="password" @value={{this.password}} name="password"
+             class="sm:col-span-7" />
+    {{/if}}
+  </div>
+
+  {{#if this.connectError}}
+    <FlashMessageError @title={{this.connectError.title}}
+                       @content={{this.connectError.content}}
+                       class="mt-4" />
+  {{/if}}
+
+  <div class="w-full mt-10 sm:flex sm:justify-center">
+    <input type="submit" value="Continue"
+           class="w-full sm:w-1/2 btn-md btn-blue" />
+  </div>
+</form>

--- a/app/models/base_channel.js
+++ b/app/models/base_channel.js
@@ -9,7 +9,7 @@ export default class BaseChannel {
 
   @tracked account = null;
   @tracked id = '';
-  @tracked name = ''; // e.g. kosmos-dev@kosmos.chat
+  @tracked name = ''; // e.g. kosmos-dev@kosmos.chat or #kosmos-dev
   @tracked displayName = ''; // e.g. Kosmos Dev
   @tracked connected = false;
   @tracked topic = null;

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -1,6 +1,7 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import { action } from '@ember/object';
+import { isPresent } from '@ember/utils';
 
 export default class ApplicationRoute extends Route {
 
@@ -17,8 +18,12 @@ export default class ApplicationRoute extends Route {
     await this.coms.instantiateAccountsAndChannels();
     this.coms.setupListeners();
 
-    if (!this.coms.onboardingComplete &&
-        !transition.intent.url.includes('add-account')) {
+    if (isPresent(transition.intent.url) &&
+        transition.intent.url.includes('add-account')) {
+      return;
+    }
+
+    if (!this.coms.onboardingComplete) {
       this.transitionTo('welcome');
     }
 

--- a/app/services/coms.js
+++ b/app/services/coms.js
@@ -279,9 +279,8 @@ export default class ComsService extends Service {
 
   async instantiateChannels (account) {
     return this.storage.rs.kosmos.channels.getAll(account.id).then(channelData => {
-      for (const channelName in channelData) {
-        // Additional props in channelData[channelName]
-        this.createChannel(account, channelName);
+      for (const cid in channelData) {
+        this.createChannel(account, channelData[cid].name);
       }
     });
   }
@@ -433,7 +432,12 @@ export default class ComsService extends Service {
       case 'update':
         switch(message.object['@type']) {
           case 'topic':
-            this.updateChannelTopic(message);
+            if (message.actor['@type'] === 'service') {
+              // TODO (could also create a special service room)
+              // this.handleServiceAnnouncement()
+            } else {
+              this.updateChannelTopic(message);
+            }
             break;
           case 'address':
             this.updateUsername(message);

--- a/app/services/local-data.js
+++ b/app/services/local-data.js
@@ -1,13 +1,11 @@
 import Service from '@ember/service';
 import { isEmpty } from '@ember/utils';
-import config from 'hyperchannel/config/environment';
 import * as localforage from 'localforage';
+// import config from 'hyperchannel/config/environment';
 
 const defaultValues = {
   userSettings: {
-    nickname: null,
-    currentSpace: config.defaultSpaceId,
-    currentChannel: 'kosmos'
+    // nickname: null
   }
 };
 

--- a/app/services/sockethub-irc.js
+++ b/app/services/sockethub-irc.js
@@ -59,7 +59,7 @@ export default class SockethubIrcService extends Service {
   connect (account) {
     this.sockethub.ActivityStreams.Object.create({
       '@id': account.sockethubPersonId,
-      '@type': "person",
+      '@type': 'person',
       displayName: account.nickname
     });
 
@@ -73,8 +73,15 @@ export default class SockethubIrcService extends Service {
       }
     });
 
-    this.log('irc', 'connecting to IRC network', credentials);
+    console.debug('Connecting to IRC network', credentials);
     this.sockethub.socket.emit('credentials', credentials);
+
+    // TODO This is how it should work at some point. At the moment you need
+    // to join a channel in order to connect to a server automatically.
+    // const connectJob = {
+    //   '@type': 'connect', context: 'irc', actor: account.sockethubPersonId
+    // };
+    // this.sockethub.socket.emit('message', connectJob);
   }
 
   handleJoinCompleted (message) {

--- a/app/services/sockethub-irc.js
+++ b/app/services/sockethub-irc.js
@@ -86,7 +86,7 @@ export default class SockethubIrcService extends Service {
 
   handlePresenceUpdate (message) {
     const hostname = message.target['@id'].match(/(.+)\//)[1];
-    const account = this.coms.account.findBy('server.hostname', hostname);
+    const account = this.coms.accounts.findBy('server.hostname', hostname);
     if (isEmpty(account)) { console.warn('No account for presence update message found.', message); return; }
 
     let channel = this.coms.channels.findBy('sockethubChannelId', message.target['@id']);

--- a/app/services/sockethub-irc.js
+++ b/app/services/sockethub-irc.js
@@ -6,15 +6,15 @@ import extend from 'extend';
 /**
  * Build an activity object for sending to Sockethub
  *
- * @param {Space} space - space model the activity belongs to
+ * @param {Account} account - account model the activity belongs to
  * @param {Object} details - the activity details
  * @returns {Object} the activity object
  * @private
  */
-function buildActivityObject(space, details) {
+function buildActivityObject(account, details) {
   let baseObject = {
     context: 'irc',
-    actor: space.sockethubPersonId
+    actor: account.sockethubPersonId
   };
 
   return extend({}, baseObject, details);
@@ -23,14 +23,14 @@ function buildActivityObject(space, details) {
 /**
  * Build a message object
  *
- * @param space {Space} space model instance
+ * @param account {Account} account instance
  * @param target {String} where to send the message to (channelId)
  * @param content {String} the message itself
  * @param type {String} can be either 'message' or 'me'
  * @returns {Object} the activity object
  */
-function buildMessageObject(space, target, content, type='message') {
-  return buildActivityObject(space, {
+function buildMessageObject(account, target, content, type='message') {
+  return buildActivityObject(account, {
     '@type': 'send',
     target: target,
     object: {
@@ -56,24 +56,20 @@ export default class SockethubIrcService extends Service {
    *   like e.g. `join`
    * @public
    */
-  connect (space) {
-    const actorObject = {
-      '@id': space.sockethubPersonId,
+  connect (account) {
+    this.sockethub.ActivityStreams.Object.create({
+      '@id': account.sockethubPersonId,
       '@type': "person",
-      displayName: space.server.nickname
-    };
+      displayName: account.nickname
+    });
 
-    this.sockethub.ActivityStreams.Object.create(
-      actorObject
-    );
-
-    let credentials = buildActivityObject(space, {
+    const credentials = buildActivityObject(account, {
       object: {
         '@type': 'credentials',
-        nick: space.server.nickname,
-        server: space.server.hostname,
-        port: parseInt(space.server.port, 10),
-        secure: space.server.secure
+        nick: account.nickname,
+        server: account.server.hostname,
+        port: parseInt(account.server.port, 10),
+        secure: account.server.secure
       }
     });
 
@@ -89,23 +85,16 @@ export default class SockethubIrcService extends Service {
   }
 
   handlePresenceUpdate (message) {
-    let hostname;
-    if (typeof message.target === 'object') {
-      hostname = message.target['@id'].match(/(.+)\//)[1];
-    }
+    const hostname = message.target['@id'].match(/(.+)\//)[1];
+    const account = this.coms.account.findBy('server.hostname', hostname);
+    if (isEmpty(account)) { console.warn('No account for presence update message found.', message); return; }
 
-    let space = this.coms.spaces.findBy('server.hostname', hostname);
+    let channel = this.coms.channels.findBy('sockethubChannelId', message.target['@id']);
 
-    if (isEmpty(space)) {
-      console.warn('No space for presence update message found.', message);
-      return;
-    }
-
-    let channel = space.channels.findBy('sockethubChannelId', message.target['@id']);
-
+    // TODO document why there might be no channel instance, or remove
     if (isEmpty(channel)) {
-      console.warn('No channel for presence update message found. Creating it.', message);
-      channel = this.coms.createChannel(space, message.target['displayName'], message.target['@id']);
+      console.debug('No channel for presence update message found. Creating it.', message);
+      channel = this.coms.createChannel(account, message.target.displayName, message.target['@id']);
     }
 
     // Hotfix for adding one's own user to the channel and marking it as
@@ -113,7 +102,7 @@ export default class SockethubIrcService extends Service {
     // ATM, Sockethub doesn't send any events or information that we
     // successfully joined a channel. So for now we just assume, if we receive
     // presence updates from other users, we should be in the channel, too.
-    channel.addUser(space.userNickname);
+    channel.addUser(account.nickname);
     channel.connected = true;
 
     channel.addUser(message.actor.displayName);
@@ -123,7 +112,7 @@ export default class SockethubIrcService extends Service {
    * Join a channel/room
    * @public
    */
-  join (space, channel, type) {
+  join (channel, type) {
     switch(type) {
       case 'room':
         this.sockethub.ActivityStreams.Object.create({
@@ -132,7 +121,7 @@ export default class SockethubIrcService extends Service {
           displayName: channel.name
         });
 
-        var joinMsg = buildActivityObject(space, {
+        var joinMsg = buildActivityObject(channel.account, {
           '@type': 'join',
           target: channel.sockethubChannelId,
           object: {}
@@ -151,8 +140,9 @@ export default class SockethubIrcService extends Service {
    * Send a chat message to a channel
    * @public
    */
-  transferMessage (space, target, content) {
-    let message = buildMessageObject(space, target, content);
+  transferMessage (target, content) {
+    const channel = this.coms.getChannel(target['@id']);
+    const message = buildMessageObject(channel.account, target, content);
 
     this.log('send', 'sending message job', message);
     this.sockethub.socket.emit('message', message);
@@ -162,8 +152,9 @@ export default class SockethubIrcService extends Service {
    * Send an action chat message to a channel
    * @public
    */
-  transferMeMessage (space, target, content) {
-    let message = buildMessageObject(space, target, content, 'me');
+  transferMeMessage (target, content) {
+    const channel = this.coms.getChannel(target['@id']);
+    const message = buildMessageObject(channel.account, target, content, 'me');
 
     this.log('send', 'sending message job', message);
     this.sockethub.socket.emit('message', message);
@@ -176,14 +167,14 @@ export default class SockethubIrcService extends Service {
    */
   addMessageToChannel (message) {
     const hostname = message.actor['@id'].match(/.+@(.+)/)[1];
-    const space = this.coms.spaces.findBy('server.hostname', hostname);
+    const account = this.coms.account.findBy('server.hostname', hostname);
 
-    if (isEmpty(space)) {
-      console.warn('Could not find space for message', message);
+    if (isEmpty(account)) {
+      console.warn('Could not find account for message', message);
       return;
     }
 
-    const channel = this.getChannelForMessage(space, message);
+    const channel = this.getChannelForMessage(account, message);
     const channelMessage = channelMessageFromSockethubObject(message);
 
     channel.addMessage(channelMessage);
@@ -193,7 +184,7 @@ export default class SockethubIrcService extends Service {
    * Leave a channel
    * @public
    */
-  leave (space, channel) {
+  leave (channel) {
     if (!channel.isUserChannel) {
       // TODO Do we really need to create this room for leaving? It should
       // already have been created when joining.
@@ -203,7 +194,7 @@ export default class SockethubIrcService extends Service {
         displayName: channel.name
       });
 
-      let leaveMsg = buildActivityObject(space, {
+      let leaveMsg = buildActivityObject(channel.account, {
         '@type': 'leave',
         target: channel.sockethubChannelId,
         object: {}
@@ -218,8 +209,8 @@ export default class SockethubIrcService extends Service {
    * Send a channel topic change
    * @public
    */
-  changeTopic (space, channel, topic) {
-    let topicMsg = buildActivityObject(space, {
+  changeTopic (channel, topic) {
+    let topicMsg = buildActivityObject(channel.account, {
       '@type': 'update',
       target: channel.sockethubChannelId,
       object: {
@@ -235,8 +226,8 @@ export default class SockethubIrcService extends Service {
    * Ask for a channel's attendance list (users currently joined)
    * @public
    */
-  observeChannel (space, channel) {
-    let observeMsg = buildActivityObject(space, {
+  observeChannel (channel) {
+    let observeMsg = buildActivityObject(channel.account, {
       '@type': 'observe',
       target: channel.sockethubChannelId,
       object: {
@@ -249,31 +240,31 @@ export default class SockethubIrcService extends Service {
   }
 
   /**
-   * Get the channel for the given space and message.
+   * Get the channel for the given account and message.
    *
-   * @param {Space} space
+   * @param {Account} account
    * @param {Object} message
    * @returns {Channel} channel
    * @public
    */
-  getChannelForMessage (space, message) {
+  getChannelForMessage (account, message) {
     let targetChannelName, channel;
 
-    if (space.userNickname === message.target.displayName) {
-      // direct message
+    if (account.nickname === message.target.displayName) {
+      // Direct message
       targetChannelName = message.actor.displayName || message.actor['@id'];
-
-      channel = space.channels.findBy('name', targetChannelName);
+      channel = this.coms.channels.filterBy('account', account)
+                                  .findBy('name', targetChannelName);
       if (!channel) {
-        channel = this.coms.createUserChannel(space, targetChannelName);
+        channel = this.coms.createUserChannel(account, targetChannelName);
       }
     } else {
-      // channel message
+      // Channel message
       targetChannelName = message.target.displayName;
-
-      channel = space.channels.findBy('name', targetChannelName);
+      channel = this.coms.channels.filterBy('account', account)
+                                  .findBy('name', targetChannelName);
       if (!channel) {
-        channel = this.coms.createChannel(space, targetChannelName);
+        channel = this.coms.createChannel(account, targetChannelName);
       }
     }
 

--- a/app/services/sockethub-irc.js
+++ b/app/services/sockethub-irc.js
@@ -174,7 +174,7 @@ export default class SockethubIrcService extends Service {
    */
   addMessageToChannel (message) {
     const hostname = message.actor['@id'].match(/.+@(.+)/)[1];
-    const account = this.coms.account.findBy('server.hostname', hostname);
+    const account = this.coms.accounts.findBy('server.hostname', hostname);
 
     if (isEmpty(account)) {
       console.warn('Could not find account for message', message);


### PR DESCRIPTION
* Add component for setting up IRC accounts
* Adapt IRC sockethub service and other relevant code for the new data model
* Fix some small things

Note:

* DMs are still disabled in the UI for now
* There's some commented code to implement when Sockethub implements a connect command for IRC (currently being done automatically on channel joins).