### PR TITLE
Remove channel from storage when leaving

### DIFF
--- a/app/services/coms.js
+++ b/app/services/coms.js
@@ -369,11 +369,8 @@ export default class ComsService extends Service {
   removeChannel (channelName) {
     const channel = this.channels.findBy('name', channelName);
     this.leaveChannel(channel);
-
     this.channels.removeObject(channel);
-
-    // TODO delete from RS?
-
+    this.storage.removeChannel(channel);
     return channel;
   }
 

--- a/app/services/remotestorage.js
+++ b/app/services/remotestorage.js
@@ -75,4 +75,10 @@ export default class RemotestorageService extends Service {
       .catch(err => console.error('saving channel failed:', err));
   }
 
+  removeChannel (channel) {
+    return this.rs.kosmos.channels.remove(channel.account.id, channel.id)
+      .then(() => console.debug(`removed channel ${channel.id}`))
+      .catch(err => console.error('removing channel failed:', err));
+  }
+
 }


### PR DESCRIPTION
Required a fix for the RS module, so you'll have to delete the node module and `npm i` again to have this one working: https://github.com/67P/remotestorage-module-kosmos/commit/ec6bb0b2ba602cc238728c02b5decdb95ae6b503

refs #227