### PR TITLE
Pending status for outgoing XMPP messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Build Status](https://travis-ci.com/67P/hyperchannel.svg?branch=master)](https://travis-ci.org/67P/hyperchannel)
-[![devDependency Status](https://david-dm.org/67P/hyperchannel/dev-status.svg)](https://david-dm.org/67P/hyperchannel#info=devDependencies)
 [![Code Climate](https://img.shields.io/codeclimate/maintainability/67P/hyperchannel.svg)](https://codeclimate.com/github/67P/hyperchannel)
+[![devDependency Status](https://david-dm.org/67P/hyperchannel/dev-status.svg)](https://david-dm.org/67P/hyperchannel#info=devDependencies)
 
 # Hyperchannel (pre-alpha!)
 

--- a/app/components/message-chat/component.js
+++ b/app/components/message-chat/component.js
@@ -47,6 +47,10 @@ export default class MessageChatComponent extends Component {
     return htmlSafe(out);
   }
 
+  get pendingClass () {
+    return this.args.message.pending ? 'text-gray-500' : '';
+  }
+
   @action
   usernameClick (username) {
     this.args.onUsernameClick(username);

--- a/app/components/message-chat/template.hbs
+++ b/app/components/message-chat/template.hbs
@@ -1,11 +1,12 @@
-<div class="chat-message">
-  <span class="chat-message__username"
-        data-username={{@message.nickname}}
-        onclick={{fn this.usernameClick @message.nickname}}>
+<div class="chat-message break-words">
+  <span data-username={{@message.nickname}}
+        onclick={{fn this.usernameClick @message.nickname}}
+        class="mr-1 font-bold" >
     {{@message.nickname}}:
   </span>
 
-  <time class="chat-message__date" datetime={{this.datetime}} title={{this.dateTitle}}>
+  <time datetime={{this.datetime}} title={{this.dateTitle}}
+        class="block float-right text-sm text-gray-300" >
     {{moment-format @message.date "HH:mm"}}
   </time>
 

--- a/app/components/message-chat/template.hbs
+++ b/app/components/message-chat/template.hbs
@@ -1,7 +1,7 @@
 <div class="chat-message break-words">
   <span data-username={{@message.nickname}}
         onclick={{fn this.usernameClick @message.nickname}}
-        class="mr-1 font-bold" >
+        class="mr-1 font-bold {{this.pendingClass}}" >
     {{@message.nickname}}:
   </span>
 
@@ -10,7 +10,7 @@
     {{moment-format @message.date "HH:mm"}}
   </time>
 
-  <span class="chat-message__message">
+    <span class="{{this.pendingClass}}">
     {{this.formattedContent}}
   </span>
 </div>

--- a/app/controllers/base_channel.js
+++ b/app/controllers/base_channel.js
@@ -16,14 +16,20 @@ export default class BaseChannelController extends Controller {
 
   @alias('application.showChannelMenu') showChannelMenu;
 
-  createMessage (message, type) {
-    return new Message({
+  createMessage (content, type) {
+    const message = new Message({
       type: type,
       date: new Date(),
       // TODO  nickname per channel
       nickname: this.model.account.nickname,
-      content: message
+      content: content
     });
+
+    if (this.model.protocol === 'XMPP') {
+      message.pending = true;
+    }
+
+    return message;
   }
 
   @computed('router.currentRouteName')

--- a/app/controllers/base_channel.js
+++ b/app/controllers/base_channel.js
@@ -4,6 +4,7 @@ import { alias } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
 import { isPresent } from '@ember/utils';
 import { tracked } from '@glimmer/tracking';
+import Channel from 'hyperchannel/models/channel';
 import Message from 'hyperchannel/models/message';
 
 export default class BaseChannelController extends Controller {
@@ -25,7 +26,10 @@ export default class BaseChannelController extends Controller {
       content: content
     });
 
-    if (this.model.protocol === 'XMPP') {
+    // We only receive our own message from XMPP MUCs (but not DMs)
+    // TODO implement message carbons or another way of verifying sent status
+    if (this.model.protocol === 'XMPP' &&
+       (this.model instanceof Channel)) {
       message.pending = true;
     }
 

--- a/app/controllers/base_channel.js
+++ b/app/controllers/base_channel.js
@@ -63,12 +63,10 @@ export default class BaseChannelController extends Controller {
   sendMessage (newMessage) {
     const message = this.createMessage(newMessage, 'message-chat');
 
-    this.coms.transferMessage(
-      this.model,
-      message.content
-    );
+    this.coms.transferMessage(this.model, message.content);
 
     this.model.addMessage(message);
+
     this.newMessage = null;
   }
 

--- a/app/models/base_channel.js
+++ b/app/models/base_channel.js
@@ -132,6 +132,18 @@ export default class BaseChannel {
     }
   }
 
+  confirmPendingMessage (content) {
+    const message = this.messages.filterBy('pending')
+                                 .findBy('content', content);
+
+    if (isPresent(message)) {
+      message.pending = false;
+      return true;
+    } else {
+      return false;
+    }
+  }
+
   addUser(username) {
     if (!this.userList.includes(username)) {
       this.userList.pushObject(username);

--- a/app/models/message.js
+++ b/app/models/message.js
@@ -6,6 +6,7 @@ export default class Message {
   @tracked date = null;
   @tracked nickname = null;
   @tracked content = null;
+  @tracked pending = null;
 
   constructor (props) {
     Object.assign(this, props);

--- a/app/services/sockethub-xmpp.js
+++ b/app/services/sockethub-xmpp.js
@@ -188,12 +188,17 @@ export default class SockethubXmppService extends Service {
     if (isEmpty(message.object.content)) return;
 
     const channel = this.findOrCreateChannelForMessage(message);
-    const channelMessage = channelMessageFromSockethubObject(message);
 
-    // TODO should check for message and update sent status if exists
-    if (channelMessage.nickname !== channel.account.nickname) {
-      channel.addMessage(channelMessage);
+    // TODO implement message carbons
+    // https://xmpp.org/extensions/xep-0280.html
+    if (message.actor.displayName &&
+       (message.actor.displayName === channel.account.nickname)) {
+      const pendingConfirmed = channel.confirmPendingMessage(message.object.content);
+      if (pendingConfirmed) return;
     }
+
+    const channelMessage = channelMessageFromSockethubObject(message);
+    channel.addMessage(channelMessage);
   }
 
   /**

--- a/app/styles/components/message-chat.scss
+++ b/app/styles/components/message-chat.scss
@@ -42,31 +42,6 @@
     font-style: italic;
   }
 
-  &__date {
-    display: block;
-    float: right;
-    font-size: 12px;
-    color: #ccc;
-  }
-
-  &__username {
-    margin-right: 0.2em;
-    font-weight: bold;
-
-    // &[data-username=raucao] {
-    //   background: url(/img/avatar-sk.png) 0 2px no-repeat;
-    // }
-    // &[data-username=silverbucket] {
-    //   background: url(/img/avatar-sb.png) 0 2px no-repeat;
-    // }
-    // &[data-username=galfert] {
-    //   background: url(/img/avatar-ga.jpeg) 0 2px no-repeat;
-    // }
-  }
-
-  &__message {
-  }
-
   a {
     text-decoration: underline;
     color: #339;

--- a/tests/fixtures/accounts.js
+++ b/tests/fixtures/accounts.js
@@ -7,5 +7,6 @@ export const ircAccount = new IrcAccount({
 });
 
 export const xmppAccount = new XmppAccount({
+  nickname: 'jimmy',
   username: 'jimmy@kosmos.org'
 });


### PR DESCRIPTION
This marks outgoing messages as pending, and then confirms that they were sent when received back from the room. It also fixes the problem of one's own messages missing in the chat history that is sent by XMPP servers upon joining a channel.

<del>Note: will probably fail with DMs (#242), because we would need message carbons for those. Hence the WIP, until DMs are merged.</del> Fixed for DMs.

---

P.S.: I think we'll want to have a timeout for showing messages as pending in the UI later on. Currently, there's a bit of a flash from switching the text color after a split second. And we can also add an actual text marker or other indicator, after a few seconds of it not having confirmed.