### PR TITLE
Send and handle leave messages for XMPP MUC

### DIFF
--- a/app/services/coms.js
+++ b/app/services/coms.js
@@ -173,7 +173,7 @@ export default class ComsService extends Service {
   leaveChannel (channel) {
     switch (channel.protocol) {
       case 'XMPP':
-        // TODO implement
+        this.xmpp.leave(channel);
         break;
       case 'IRC':
         this.irc.leave(channel);

--- a/app/services/coms.js
+++ b/app/services/coms.js
@@ -171,14 +171,8 @@ export default class ComsService extends Service {
   }
 
   leaveChannel (channel) {
-    switch (channel.protocol) {
-      case 'XMPP':
-        this.xmpp.leave(channel);
-        break;
-      case 'IRC':
-        this.irc.leave(channel);
-        break;
-    }
+    this.getServiceForSockethubPlatform(channel.protocol)
+        .leave(channel);
   }
 
   changeTopic (channel, topic) {

--- a/app/services/sockethub-irc.js
+++ b/app/services/sockethub-irc.js
@@ -194,14 +194,6 @@ export default class SockethubIrcService extends Service {
    */
   leave (channel) {
     if (!channel.isUserChannel) {
-      // TODO Do we really need to create this room for leaving? It should
-      // already have been created when joining.
-      this.sockethub.ActivityStreams.Object.create({
-        '@type': "room",
-        '@id': channel.sockethubChannelId,
-        displayName: channel.name
-      });
-
       let leaveMsg = buildActivityObject(channel.account, {
         '@type': 'leave',
         target: channel.sockethubChannelId,

--- a/app/services/sockethub-xmpp.js
+++ b/app/services/sockethub-xmpp.js
@@ -174,6 +174,19 @@ export default class SockethubXmppService extends Service {
           channel.addUser(message.actor.displayName);
         }
       }
+    } else if (message.actor['@type'] === 'person' && message.actor['@id'].match(/\/(.+)$/)) {
+      const sockethubActorId = message.actor['@id'];
+      const targetChannelId = sockethubActorId.match(/^(.+)\//)[1];
+      const channel = this.coms.getChannel(targetChannelId);
+      const displayName = sockethubActorId.match(/\/(.+)$/)[1];
+
+      if (channel) {
+        if (message.object.presence === 'unavailable') {
+          channel.removeUser(displayName);
+        } else {
+          channel.addUser(displayName);
+        }
+      }
     } else {
       this.log('xmpp', 'presence update from contact:', message.actor['@id'], message.object.presence, message.object.status);
     }

--- a/app/services/sockethub-xmpp.js
+++ b/app/services/sockethub-xmpp.js
@@ -201,6 +201,19 @@ export default class SockethubXmppService extends Service {
     channel.addMessage(channelMessage);
   }
 
+  leave (channel) {
+    if (!channel.isUserChannel) {
+      const leaveMsg = buildActivityObject(channel.account, {
+        '@type': 'leave',
+        target: channel.sockethubChannelId,
+        object: {}
+      });
+
+      this.log('leave', 'leaving channel', leaveMsg);
+      this.sockethub.socket.emit('message', leaveMsg);
+    }
+  }
+
   /**
    * Ask for a channel's attendance list (users currently joined)
    *


### PR DESCRIPTION
Closes #239

During testing I noticed that Sockethub actually sends "online" presence updates for incoming "unavailable" stanzas. I've created an issue for that at https://github.com/sockethub/sockethub/issues/564.

This PR also deletes the creation of the ActivityStream object when leaving an IRC room, because I confirmed that it's not needed.