### PR TITLE
Fix redirects causing duplicate setup method calls

### DIFF
--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -10,7 +10,7 @@ export default class ApplicationRoute extends Route {
   @service logger;
   @service coms;
 
-  async beforeModel (transition) {
+  async beforeModel () {
     super.beforeModel(...arguments);
 
     await this.storage.ensureReadiness();
@@ -18,6 +18,15 @@ export default class ApplicationRoute extends Route {
     await this.coms.instantiateAccountsAndChannels();
     this.coms.setupListeners();
 
+    // See a list of allowed types in logger.js
+    // Add or remove all your log types here:
+    // this.logger.add('message');
+    // this.logger.remove('join');
+    // this.logger.disable();
+    // this.logger.enable();
+  }
+
+  redirect (model, transition) {
     if (isPresent(transition.intent.url) &&
         transition.intent.url.includes('add-account')) {
       return;
@@ -26,13 +35,6 @@ export default class ApplicationRoute extends Route {
     if (!this.coms.onboardingComplete) {
       this.transitionTo('welcome');
     }
-
-    // See a list of allowed types in logger.js
-    // Add or remove all your log types here:
-    // this.logger.add('message');
-    // this.logger.remove('join');
-    // this.logger.disable();
-    // this.logger.enable();
   }
 
   @action


### PR DESCRIPTION
Triggering a transition from the beforeModel method in the application route will cause the beforeModel method to be called again on the next transition. Moving the transition call to the redirect method fixes this.