### PR TITLE
Integration tests for join-channel-* components

### DIFF
--- a/app/components/join-channel-xmpp/template.hbs
+++ b/app/components/join-channel-xmpp/template.hbs
@@ -13,13 +13,15 @@
              class="flex-none ml-4 btn-md btn-blue" />
     </div>
   </div>
+  {{!--
   <!-- TODO -->
-  <!-- <div class="mt-6"> -->
-  <!--   Advanced options -->
-  <!-- </div> -->
-  <!-- <div class="mt&#45;6 grid grid&#45;cols&#45;1 gap&#45;2 sm:grid&#45;cols&#45;10 sm:gap&#45;4 sm:items&#45;center"> -->
-  <!--   <label for="nickname" class="sm:col&#45;span&#45;3 pr&#45;4">Nickname</label> -->
-  <!--   <Input name="nickname" @type="text" @value={{this.nickname}} -->
-  <!--          required class="sm:col&#45;span&#45;7" /> -->
-  <!-- </div> -->
+  <div class="mt-6">
+    Advanced options
+  </div>
+  <div class="mt-6 grid grid-cols-1 gap-2 sm:grid-cols-10 sm:gap-4 sm:items-center">
+    <label for="nickname" class="sm:col-span-3 pr-4">Nickname</label>
+    <Input name="nickname" @type="text" @value={{this.nickname}}
+           required class="sm:col-span-7" />
+  </div>
+  --}}
 </form>

--- a/tests/integration/components/join-channel-irc/component-test.js
+++ b/tests/integration/components/join-channel-irc/component-test.js
@@ -1,17 +1,90 @@
-import { module, skip } from 'qunit';
+import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { click, fillIn, render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
+import Service from '@ember/service';
+
+class comsStub extends Service {}
 
 module('Integration | Component | join-channel-irc', function(hooks) {
   setupRenderingTest(hooks);
 
-  skip('it renders', async function(assert) {
-    // Set any properties with this.set('myProperty', 'value');
-    // Handle any actions with this.set('myAction', function(val) { ... });
+  hooks.beforeEach(function() {
+    this.owner.register('service:coms', comsStub);
 
-    await render(hbs`<JoinChannelIrc />`);
+    const coms = this.owner.lookup('service:coms');
+    coms.createChannel = function () {};
+    this.set('coms', coms);
 
-    assert.equal(this.element.textContent.trim(), '');
+    const router = this.owner.lookup('service:router');
+    router.transitionTo = function () {};
+    this.set('router', router);
+
+    const account = { id: 'irc-account' };
+    this.set('account', account);
+    this.set('close', function () {});
+  });
+
+  test('creates a channel with the given name on the passed account', async function(assert) {
+    assert.expect(3);
+
+    this.coms.createChannel = function (account, channelName) {
+      assert.equal(account.id, 'irc-account', 'uses the selected account');
+      assert.equal(channelName, '#kosmos-random', 'uses the given channel address');
+    }
+
+    await render(hbs`<JoinChannelIrc @account={{this.account}} @closeModal={{this.close}} />`);
+
+    const channelInput = 'input[name="channel-name"]';
+
+    assert.dom(channelInput).isFocused();
+
+    await fillIn(channelInput, '#kosmos-random');
+    await click('input[type="submit"]');
+  });
+
+  test('it prefixes the entered channel name with # when none given', async function(assert) {
+    assert.expect(2);
+
+    this.coms.createChannel = function (account, channelName) {
+      assert.equal(account.id, 'irc-account', 'uses the selected account');
+      assert.equal(channelName, '#kosmos-random', 'uses the given channel address');
+    }
+
+    await render(hbs`<JoinChannelIrc @account={{this.account}} @closeModal={{this.close}} />`);
+
+    await fillIn('input[name="channel-name"]', 'kosmos-random');
+    await click('input[type="submit"]');
+  });
+
+  test('it sends the user to the created channel', async function(assert) {
+    assert.expect(2);
+
+    this.coms.createChannel = function () {
+      return 'channel-model';
+    }
+
+    this.router.transitionTo = function (route, model) {
+      assert.equal(route, 'channel');
+      assert.equal(model, 'channel-model');
+    };
+
+    await render(hbs`<JoinChannelIrc @account={{this.account}} @closeModal={{this.close}} />`);
+
+    await fillIn('input[name="channel-name"]', 'kosmos-random');
+    await click('input[type="submit"]');
+  });
+
+  test('it closes the modal when finished', async function(assert) {
+    assert.expect(1);
+
+    this.set('close', function () {
+      assert.ok(true);
+    });
+
+    await render(hbs`<JoinChannelIrc @account={{this.account}} @closeModal={{this.close}} />`);
+
+    await fillIn('input[name="channel-name"]', 'kosmos-random');
+    await click('input[type="submit"]');
   });
 });

--- a/tests/integration/components/join-channel-xmpp/component-test.js
+++ b/tests/integration/components/join-channel-xmpp/component-test.js
@@ -1,17 +1,76 @@
-import { module, skip } from 'qunit';
+import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { click, fillIn, render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
+import Service from '@ember/service';
+
+class comsStub extends Service {}
 
 module('Integration | Component | join-channel-xmpp', function(hooks) {
   setupRenderingTest(hooks);
 
-  skip('it renders', async function(assert) {
-    // Set any properties with this.set('myProperty', 'value');
-    // Handle any actions with this.set('myAction', function(val) { ... });
+  hooks.beforeEach(function() {
+    this.owner.register('service:coms', comsStub);
 
-    await render(hbs`<JoinChannelXmpp />`);
+    const coms = this.owner.lookup('service:coms');
+    coms.createChannel = function () {};
+    this.set('coms', coms);
 
-    assert.equal(this.element.textContent.trim(), '');
+    const router = this.owner.lookup('service:router');
+    router.transitionTo = function () {};
+    this.set('router', router);
+
+    const account = { id: 'xmpp-account' };
+    this.set('account', account);
+    this.set('close', function () {});
+  });
+
+  test('creates a channel with the given name on the passed account', async function(assert) {
+    assert.expect(3);
+
+    this.coms.createChannel = function (account, channelName) {
+      assert.equal(account.id, 'xmpp-account', 'uses the selected account');
+      assert.equal(channelName, 'kosmos-random@kosmos.chat', 'uses the given channel address');
+    }
+
+    await render(hbs`<JoinChannelXmpp @account={{this.account}} @closeModal={{this.close}} />`);
+
+    const channelInput = 'input[name="channel-name"]';
+
+    assert.dom(channelInput).isFocused();
+
+    await fillIn(channelInput, 'kosmos-random');
+    await click('input[type="submit"]');
+  });
+
+  test('it sends the user to the created channel', async function(assert) {
+    assert.expect(2);
+
+    this.coms.createChannel = function () {
+      return 'channel-model';
+    }
+
+    this.router.transitionTo = function (route, model) {
+      assert.equal(route, 'channel');
+      assert.equal(model, 'channel-model');
+    };
+
+    await render(hbs`<JoinChannelXmpp @account={{this.account}} @closeModal={{this.close}} />`);
+
+    await fillIn('input[name="channel-name"]', 'kosmos-random');
+    await click('input[type="submit"]');
+  });
+
+  test('it closes the modal when finished', async function(assert) {
+    assert.expect(1);
+
+    this.set('close', function () {
+      assert.ok(true);
+    });
+
+    await render(hbs`<JoinChannelXmpp @account={{this.account}} @closeModal={{this.close}} />`);
+
+    await fillIn('input[name="channel-name"]', 'kosmos-random');
+    await click('input[type="submit"]');
   });
 });


### PR DESCRIPTION
This also changes the comment style of the commented code in the `join-channel-xmpp` component to fix the linter errors about HTML comments.

After merging #254 should be all green.