### PR TITLE
Fix outgoing message correction property name

### DIFF
--- a/app/services/sockethub-xmpp.js
+++ b/app/services/sockethub-xmpp.js
@@ -42,7 +42,7 @@ function buildMessageObject(account, target, message) {
   });
 
   if (message.replaceId) {
-    job.object['replace'] = { id: message.replaceId };
+    job.object['xmpp:replace'] = { id: message.replaceId };
   }
 
   return job;

--- a/tests/unit/services/sockethub-xmpp-test.js
+++ b/tests/unit/services/sockethub-xmpp-test.js
@@ -185,6 +185,6 @@ module('Unit | Service | sockethub xmpp', function(hooks) {
 
     const jobMessage = socketEmitSpy.getCall(0).args[1];
     assert.equal(jobMessage.object.id, 'hc-123abcde', 'job object contains a message ID');
-    assert.deepEqual(jobMessage.object.replace, { id: 'hc-234ghijk' }, 'job object contains the replace property');
+    assert.deepEqual(jobMessage.object['xmpp:replace'], { id: 'hc-234ghijk' }, 'job object contains the replace property');
   });
 });


### PR DESCRIPTION
Was not consistent with incoming AS messages.

Works with the latest commit in sockethub/sockethub#653.