### PR TITLE
Grouped chat messages

### DIFF
--- a/app/components/date-headline/template.hbs
+++ b/app/components/date-headline/template.hbs
@@ -1,4 +1,4 @@
-<div class="relative my-6 mx-4" {{did-insert this.scheduleUpdate}}>
+<div class="relative my-4 mx-4" {{did-insert this.scheduleUpdate}}>
   <div class="absolute inset-0 flex items-center" aria-hidden="true">
     <div class="w-full border-t border-gray-200"></div>
   </div>

--- a/app/components/message-chat/component.js
+++ b/app/components/message-chat/component.js
@@ -4,13 +4,21 @@ import { action } from '@ember/object';
 import { htmlSafe } from '@ember/string';
 import { tracked } from '@glimmer/tracking';
 import { scheduleOnce } from '@ember/runloop';
-import moment from 'moment';
 import { isEmpty } from '@ember/utils';
+import moment from 'moment';
+import getRGB from 'consistent-color-generation';
 
 export default class MessageChatComponent extends Component {
 
   @tracked isEditing = false;
   @tracked editedContent = null;
+
+  constructor () {
+    super(...arguments);
+    // TODO move to user object when implemented
+    // https://github.com/67P/hyperchannel/issues/180
+    this.userColorHex = getRGB(this.args.message.nickname).toString();
+  }
 
   get datetime () {
     return moment(this.args.message.date).format('YYYY-MM-DD[T]HH:mm');
@@ -55,6 +63,10 @@ export default class MessageChatComponent extends Component {
 
   get pendingClass () {
     return this.args.message.pending ? 'text-gray-500' : '';
+  }
+
+  get avatarPlaceholderLetter () {
+    return this.args.message.nickname.charAt(0).toUpperCase();
   }
 
   focusInputField(messageId) {

--- a/app/components/message-chat/template.hbs
+++ b/app/components/message-chat/template.hbs
@@ -1,4 +1,5 @@
 <div class="chat-message group relative px-4 py-1 break-words hover:bg-gray-100">
+  {{#unless @message.grouped}}
   <div class="text-sm">
     <span data-username={{@message.nickname}}
           onclick={{fn this.usernameClick @message.nickname}}
@@ -10,6 +11,7 @@
       {{moment-format @message.date "HH:mm"}}
     </time>
   </div>
+  {{/unless}}
 
   {{#if this.isEditing}}
   <form {{on "submit" this.correctMessage}}>

--- a/app/components/message-chat/template.hbs
+++ b/app/components/message-chat/template.hbs
@@ -1,47 +1,60 @@
-<div class="chat-message group relative px-4 py-1 break-words hover:bg-gray-100">
-  {{#unless @message.grouped}}
-  <div class="text-sm">
-    <span data-username={{@message.nickname}}
-          onclick={{fn this.usernameClick @message.nickname}}
-          class="mr-1 font-bold {{this.pendingClass}}" >
-      {{@message.nickname}}
-    </span>
-    <time datetime={{this.datetime}} title={{this.dateTitle}}
-          class="text-gray-300 group-hover:text-gray-400" >
-      {{moment-format @message.date "HH:mm"}}
-    </time>
+<div class="chat-message group mt-1 px-4 py-0.5 hover:bg-gray-100 flex space-x-3
+            {{if @message.grouped 'mt-0'}}">
+  <div class="msg-avatar w-10">
+    {{#unless @message.grouped}}
+      <span class="w-10 h-10 flex justify-center items-center text-center
+                   text-white text-xl rounded bg-gray-200">
+        <span class="flex-1" style={{html-safe (concat "color: " this.userColorHex)}}>
+          {{this.avatarPlaceholderLetter}}
+        </span>
+      </span>
+    {{/unless}}
   </div>
-  {{/unless}}
+  <div class="flex-1 relative">
+    {{#unless @message.grouped}}
+    <div class="msg-meta text-sm">
+      <span data-username={{@message.nickname}}
+            onclick={{fn this.usernameClick @message.nickname}}
+            class="mr-1 font-bold {{this.pendingClass}}" >
+        {{@message.nickname}}
+      </span>
+      <time datetime={{this.datetime}} title={{this.dateTitle}}
+            class="text-gray-300 group-hover:text-gray-400" >
+        {{moment-format @message.date "HH:mm"}}
+      </time>
+    </div>
+    {{/unless}}
 
-  {{#if this.isEditing}}
-  <form {{on "submit" this.correctMessage}}>
-    <label><span class="invisible">Message</span>
-      <Input @type="text" @value={{this.editedContent}}
-             name="message-input-{{@message.id}}"
-             autocomplete="off"
-             class="mt-2 mr-1 py-1.5 md:w-1/2 group-hover:bg-white" />
-    </label>
-    <button type="submit" title="Send"
-            class="btn-icon-sm btn-blue align-middle mr-0.5">
-      <IconSend />
-    </button>
-    <button {{on "click" this.cancelMessageCorrection}}
-            type="reset" title="Cancel"
-            class="btn-icon-sm btn-red align-middle">
-      <IconX />
-    </button>
-  </form>
-  {{else}}
-  <span class="{{this.pendingClass}}">
-    {{this.formattedContent}}
-    {{#if @message.edited}}
-    <span title="Edited">
-      <IconEdit @class="inline w-4 h-4 text-gray-300 group-hover:text-gray-400" />
-    </span>
+    {{#if this.isEditing}}
+    <form {{on "submit" this.correctMessage}}>
+      <label><span class="invisible">Message</span>
+        <Input @type="text" @value={{this.editedContent}}
+               name="message-input-{{@message.id}}"
+               autocomplete="off"
+               class="mt-2 mr-1 py-1.5 md:w-1/2 group-hover:bg-white" />
+      </label>
+      <button type="submit" title="Send"
+              class="btn-icon-sm btn-blue align-middle mr-0.5">
+        <IconSend />
+      </button>
+      <button {{on "click" this.cancelMessageCorrection}}
+              type="reset" title="Cancel"
+              class="btn-icon-sm btn-red align-middle">
+        <IconX />
+      </button>
+    </form>
+    {{else}}
+    <div class="msg-content break-words {{this.pendingClass}}">
+      {{this.formattedContent}}
+      {{#if @message.edited}}
+      <span title="Edited">
+        <IconEdit @class="inline w-4 h-4 text-gray-300 group-hover:text-gray-400" />
+      </span>
+      {{/if}}
+    </div>
     {{/if}}
-  </span>
-  {{/if}}
 
-  <MessageUserActions @message={{@message}} @channel={{@channel}}
-                      @onCorrectMessage={{this.startMessageCorrection}}/>
+    <MessageUserActions @message={{@message}} @channel={{@channel}}
+                        @onCorrectMessage={{this.startMessageCorrection}}/>
+  </div>
 </div>

--- a/app/helpers/html-safe.js
+++ b/app/helpers/html-safe.js
@@ -1,0 +1,6 @@
+import { helper } from '@ember/component/helper';
+import { htmlSafe } from '@ember/string';
+
+export default helper(function (params/*, hash*/) {
+  return new htmlSafe(params.join(''));
+});

--- a/app/models/base_channel.js
+++ b/app/models/base_channel.js
@@ -126,6 +126,12 @@ export default class BaseChannel {
 
     this.addDateHeadline(message);
 
+    const prevMsg = this.messages.lastObject;
+    if ((prevMsg.nickname === message.nickname) &&
+         moment(message.date).isBefore(moment(prevMsg.date).add(120, 'seconds'))) {
+      message.grouped = true;
+    }
+
     this.messages.pushObject(message);
 
     if (!this.visible) {

--- a/app/models/base_channel.js
+++ b/app/models/base_channel.js
@@ -151,6 +151,7 @@ export default class BaseChannel {
        (lastMessage.id === newMessage.replaceId)) {
       lastMessage.content = newMessage.content;
       lastMessage.edited = true;
+      // TODO replace date?
     }
   }
 

--- a/app/models/message.js
+++ b/app/models/message.js
@@ -8,6 +8,7 @@ export default class Message {
   @tracked content = null;
   @tracked pending = null;
   @tracked edited = false;
+  @tracked grouped = false;
 
   constructor (props) {
     Object.assign(this, props);

--- a/app/styles/components/message-chat.scss
+++ b/app/styles/components/message-chat.scss
@@ -1,7 +1,4 @@
 .chat-message {
-
-  word-break: break-word;
-
   // black
   .color-01 { color: #333; }
   // navy blue
@@ -42,16 +39,18 @@
     font-style: italic;
   }
 
-  a {
-    text-decoration: underline;
-    color: #339;
-  }
+  .msg-content {
+    a {
+      text-decoration: underline;
+      color: #339;
+    }
 
-  img {
-    &.from-image-url {
-      padding-top: 0.25em;
-      max-width: 500px;
-      max-height: 300px;
+    img {
+      &.from-image-url {
+        padding-top: 0.25em;
+        max-width: 500px;
+        max-height: 300px;
+      }
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@tailwindcss/forms": "^0.3.3",
         "babel-eslint": "^10.1.0",
         "broccoli-asset-rev": "^3.0.0",
+        "consistent-color-generation": "0.4.0",
         "ember-auto-import": "^1.11.3",
         "ember-autofocus-modifier": "^3.0.0",
         "ember-body-class": "^2.0.0",
@@ -7690,6 +7691,16 @@
       "version": "2.0.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/consistent-color-generation": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/consistent-color-generation/-/consistent-color-generation-0.4.0.tgz",
+      "integrity": "sha512-6OJlZgA1B+4L4BKLpHtynTOD4nA6ZAPuGgee0t/29QBLQ1JY0hNWQ4aNiVz/qMVtN0XOpwONVUNgEmRa6yc2XQ==",
+      "dev": true,
+      "dependencies": {
+        "hsluv": "^0.1.0",
+        "js-sha1": "^0.6.0"
+      }
     },
     "node_modules/console-browserify": {
       "version": "1.2.0",
@@ -16383,6 +16394,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/hsluv": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/hsluv/-/hsluv-0.1.0.tgz",
+      "integrity": "sha512-ERcanKLAszD2XN3Vh5r5Szkrv9q0oSTudmP0rkiKAGM/3NMc9FLmMZBB7TSqTaXJfSDBOreYTfjezCOYbRKqlw==",
+      "dev": true
+    },
     "node_modules/html-encoding-sniffer": {
       "version": "2.0.1",
       "dev": true,
@@ -17247,6 +17264,12 @@
       "version": "3.6.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/js-sha1": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/js-sha1/-/js-sha1-0.6.0.tgz",
+      "integrity": "sha512-01gwBFreYydzmU9BmZxpVk6svJJHrVxEN3IOiGl6VO93bVKYETJ0sIth6DASI6mIFdt7NmfX9UiByRzsYHGU9w==",
+      "dev": true
     },
     "node_modules/js-string-escape": {
       "version": "1.0.1",
@@ -31581,6 +31604,16 @@
         }
       }
     },
+    "consistent-color-generation": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/consistent-color-generation/-/consistent-color-generation-0.4.0.tgz",
+      "integrity": "sha512-6OJlZgA1B+4L4BKLpHtynTOD4nA6ZAPuGgee0t/29QBLQ1JY0hNWQ4aNiVz/qMVtN0XOpwONVUNgEmRa6yc2XQ==",
+      "dev": true,
+      "requires": {
+        "hsluv": "^0.1.0",
+        "js-sha1": "^0.6.0"
+      }
+    },
     "console-browserify": {
       "version": "1.2.0",
       "dev": true
@@ -37898,6 +37931,12 @@
       "version": "1.0.0",
       "dev": true
     },
+    "hsluv": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/hsluv/-/hsluv-0.1.0.tgz",
+      "integrity": "sha512-ERcanKLAszD2XN3Vh5r5Szkrv9q0oSTudmP0rkiKAGM/3NMc9FLmMZBB7TSqTaXJfSDBOreYTfjezCOYbRKqlw==",
+      "dev": true
+    },
     "html-encoding-sniffer": {
       "version": "2.0.1",
       "dev": true,
@@ -38433,6 +38472,12 @@
     },
     "jquery": {
       "version": "3.6.0",
+      "dev": true
+    },
+    "js-sha1": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/js-sha1/-/js-sha1-0.6.0.tgz",
+      "integrity": "sha512-01gwBFreYydzmU9BmZxpVk6svJJHrVxEN3IOiGl6VO93bVKYETJ0sIth6DASI6mIFdt7NmfX9UiByRzsYHGU9w==",
       "dev": true
     },
     "js-string-escape": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@tailwindcss/forms": "^0.3.3",
     "babel-eslint": "^10.1.0",
     "broccoli-asset-rev": "^3.0.0",
+    "consistent-color-generation": "0.4.0",
     "ember-auto-import": "^1.11.3",
     "ember-autofocus-modifier": "^3.0.0",
     "ember-body-class": "^2.0.0",

--- a/tests/integration/components/message-chat/component-test.js
+++ b/tests/integration/components/message-chat/component-test.js
@@ -1,0 +1,45 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import Channel from 'hyperchannel/models/channel';
+import Message from 'hyperchannel/models/message';
+import { xmppAccount } from '../../../fixtures/accounts';
+
+module('Integration | Component | message-chat', function(hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function() {
+    this.set('channel', new Channel({
+      account: xmppAccount, name: 'kosmos@kosmos.chat'
+    }));
+    this.set('message', new Message({
+      type: 'message-chat', id: '123abc', date: new Date(),
+      nickname: 'the_plague', content: 'never fear, i is here'
+    }));
+  });
+
+  test('it renders the message', async function(assert) {
+    await render(hbs`<MessageChat @channel={{this.channel}} @message={{this.message}} />`);
+
+    const contentEl = this.element.querySelector('.msg-content');
+    assert.equal(contentEl.innerText, this.message.content, 'renders the message content');
+
+    const metaEl = this.element.querySelector('.msg-meta');
+    assert.ok(metaEl.querySelector('span').innerText.match(this.message.nickname), `renders the sender's nickname`);
+
+    const avatarEl = this.element.querySelector('.msg-avatar');
+    assert.equal(avatarEl.querySelector('span').innerText.length, 1, `renders one letter of the sender's nickname`);
+  });
+
+  test('renders a grouped message', async function(assert) {
+    this.message.grouped = true;
+    await render(hbs`<MessageChat @channel={{this.channel}} @message={{this.message}} />`);
+
+    const contentEl = this.element.querySelector('.msg-content');
+    assert.equal(contentEl.innerText, this.message.content, 'renders the message content');
+
+    assert.notOk(this.element.querySelector('.msg-meta'), `hides the meta information`);
+    assert.notOk(this.element.querySelector('.msg-avatar span'), `hides the user avatar (placeholder)`);
+  });
+});

--- a/tests/unit/components/message-chat-test.js
+++ b/tests/unit/components/message-chat-test.js
@@ -7,7 +7,7 @@ module('Unit | Component | message-chat', function(hooks) {
 
   test('#formattedContent turns full URLs into links', function(assert) {
     let component = createComponent('component:message-chat', {
-      message: { content: 'visit https://kosmos.org for more info' }
+      message: { content: 'visit https://kosmos.org for more info', nickname: 'cerealkiller' }
     });
 
     assert.equal(component.formattedContent.toString(), 'visit <a href="https://kosmos.org" class="linkified" target="_blank" rel="nofollow noopener">https://kosmos.org</a> for more info');
@@ -15,7 +15,7 @@ module('Unit | Component | message-chat', function(hooks) {
 
   test('#formattedContent does not turn domain names into links', function(assert) {
     let component = createComponent('component:message-chat', {
-      message: { content: 'visit kosmos.org for more info' }
+      message: { content: 'visit kosmos.org for more info', nickname: 'cerealkiller' }
     });
 
     assert.equal(component.formattedContent.toString(), 'visit kosmos.org for more info');
@@ -23,7 +23,7 @@ module('Unit | Component | message-chat', function(hooks) {
 
   test('#formattedContent does not turn emails into links', function(assert) {
     let component = createComponent('component:message-chat', {
-      message: { content: 'hey team@kosmos.org' }
+      message: { content: 'hey team@kosmos.org', nickname: 'cerealkiller' }
     });
 
     assert.equal(component.formattedContent.toString(), 'hey team@kosmos.org');
@@ -31,7 +31,7 @@ module('Unit | Component | message-chat', function(hooks) {
 
   test('#formattedContent escapes HTML', function(assert) {
     let component = createComponent('component:message-chat', {
-      message: { content: 'never gonna <marquee>give you up</marquee>' }
+      message: { content: 'never gonna <marquee>give you up</marquee>', nickname: 'cerealkiller' }
     });
 
     assert.equal(component.formattedContent.toString(), 'never gonna &lt;marquee&gt;give you up&lt;/marquee&gt;');
@@ -39,7 +39,7 @@ module('Unit | Component | message-chat', function(hooks) {
 
   test('#formattedContent converts color codes', function(assert) {
     let component = createComponent('component:message-chat', {
-      message: { content: 'put some \u000313color\u000f and \u0002bold\u000f into your life. Or \u000305\u0002both\u000f' }
+      message: { content: 'put some \u000313color\u000f and \u0002bold\u000f into your life. Or \u000305\u0002both\u000f', nickname: 'cerealkiller' }
      });
 
     assert.equal(component.formattedContent.toString(), 'put some <span class="color-13">color</span> and <span class="bold">bold</span> into your life. Or <span class="color-05"><span class="bold">both</span>');
@@ -47,7 +47,7 @@ module('Unit | Component | message-chat', function(hooks) {
 
   test('#formattedContent renders images from image URLs', function(assert) {
     let component = createComponent('component:message-chat', {
-      message: { content: 'https://storage.5apps.com/basti/public/shares/160527-1119-magic.gif' }
+      message: { content: 'https://storage.5apps.com/basti/public/shares/160527-1119-magic.gif', nickname: 'cerealkiller' }
     });
 
     assert.equal(component.formattedContent.toString(), '<br><a href="https://storage.5apps.com/basti/public/shares/160527-1119-magic.gif" target="_blank" rel="nofollow noopener"><img src="https://storage.5apps.com/basti/public/shares/160527-1119-magic.gif" class="from-image-url" alt="https://storage.5apps.com/basti/public/shares/160527-1119-magic.gif"></a>');


### PR DESCRIPTION
Doesn't render every line of chat with all metadata, when the message is from the same user and in reasonably quick succession to the previous message.

I used 120 seconds as a cutoff for groupings. Not sure if that's too much already.

<img src="https://user-images.githubusercontent.com/842/148695039-9557486a-4d8e-46b2-8e7a-07e741354b2a.png" width="400" />

(The UI will be much nicer than this, and it will be even easier for the brain to parse messages belonging together, when we add avatars (with placeholders) soon.)
