### PR TITLE
Update to new XMPP credentials schema

### DIFF
--- a/app/services/sockethub-xmpp.js
+++ b/app/services/sockethub-xmpp.js
@@ -72,7 +72,7 @@ export default class SockethubXmppService extends Service {
       actor: sockethubPersonId,
       object: {
         type: 'credentials',
-        username: userAddress,
+        userAddress,
         password: password,
         resource: 'hyperchannel'
       }
@@ -112,7 +112,7 @@ export default class SockethubXmppService extends Service {
       actor: actor,
       object: {
         type: 'credentials',
-        username: account.username, // JID
+        userAddress: account.username, // JID
         password: account.password,
         resource: 'hyperchannel'
       }


### PR DESCRIPTION
`username` is now called `userAddress`, since https://github.com/sockethub/sockethub/pull/674 entered SH master.