### PR TITLE
Add SASL authentication for IRC

### DIFF
--- a/app/components/add-chat-account-irc/component.js
+++ b/app/components/add-chat-account-irc/component.js
@@ -14,29 +14,35 @@ export default class AddChatAccountIrcComponent extends Component {
   @tracked hostname = 'irc.libera.chat';
   @tracked port = '6697';
   @tracked nickname;
-  // TODO Implement authenticated connect using SASL
   // @tracked username;
-  // @tracked password;
-  // @tracked serverPassword;
+  @tracked password;
+  @tracked useAuth = false;
+  // @tracked useSasl = false;
   @tracked useTls = true;
   @tracked connectError = null;
-  @tracked showCredentialFields = false;
 
   get username () {
     return this.nickname;
   }
 
+  get useSasl () {
+    return this.useAuth;
+  }
+
   instantiateAccount () {
-    return new IrcAccount({
+    const account = new IrcAccount({
       server: {
         hostname: this.hostname,
         port: this.port,
-        secure: this.useTls
+        secure: this.useTls,
+        sasl: this.useSasl
       },
       nickname: this.nickname,
-      // username: this.username,
-      // password: this.password,
+      username: this.username,
+      password: this.password
     });
+
+    return account;
   }
 
   async addAccount () {

--- a/app/components/add-chat-account-irc/template.hbs
+++ b/app/components/add-chat-account-irc/template.hbs
@@ -14,10 +14,14 @@
     <Input id="nickname" @type="text" @value={{this.nickname}} name="nickname"
            required class="sm:col-span-7" autocomplete="username" {{autofocus}} />
 
-    {{#if this.showCredentialFields}}
-      <label for="username" class="sm:col-span-3">Username</label>
-      <Input id="username" @type="text" @value={{this.username}} name="nickname"
-             class="sm:col-span-7" />
+    <div class="mt-4 sm:mt-2 sm:col-start-4 sm:col-span-7">
+      <label>
+        <Input @type="checkbox" @checked={{this.useAuth}} class="mr-1 align-middle" />
+        <span class="font-normal text-sm text-gray-500">I have a password</span>
+      </label>
+    </div>
+
+    {{#if this.useAuth}}
       <label for="password" class="sm:col-span-3">Password</label>
       <Input id="password" @type="password" @value={{this.password}} name="password"
              class="sm:col-span-7" />

--- a/app/models/account.js
+++ b/app/models/account.js
@@ -31,7 +31,8 @@ export default class Account {
       serialized.server = {
         hostname: this.server.hostname,
         port: parseInt(this.server.port, 10),
-        secure: this.server.secure
+        secure: this.server.secure,
+        sasl: this.server.sasl
       };
     }
 

--- a/app/services/sockethub-irc.js
+++ b/app/services/sockethub-irc.js
@@ -67,10 +67,13 @@ export default class SockethubIrcService extends Service {
       type: 'credentials',
       object: {
         type: 'credentials',
-        nick: account.nickname,
         server: account.server.hostname,
         port: parseInt(account.server.port, 10),
-        secure: account.server.secure
+        secure: account.server.secure,
+        sasl: account.server.sasl,
+        nick: account.nickname,
+        // username: account.username,
+        password: account.password
       }
     });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@ember/test-helpers": "^2.2.8",
         "@glimmer/component": "^1.0.3",
         "@glimmer/tracking": "^1.0.4",
-        "@kosmos/remotestorage-module-kosmos": "^2.1.2",
+        "@kosmos/remotestorage-module-kosmos": "^2.2.0",
         "@tailwindcss/forms": "^0.3.3",
         "babel-eslint": "^10.1.0",
         "broccoli-asset-rev": "^3.0.0",
@@ -2554,9 +2554,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@kosmos/remotestorage-module-kosmos": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@kosmos/remotestorage-module-kosmos/-/remotestorage-module-kosmos-2.1.2.tgz",
-      "integrity": "sha512-aQbQ+qpQnyas54/wRL5aKxlpJV/Alu4yiEv2pc6+lO2acVcR4LlJDkqpXJU93VTvL3li+u3RdwSYbmBaQE7GVg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@kosmos/remotestorage-module-kosmos/-/remotestorage-module-kosmos-2.2.0.tgz",
+      "integrity": "sha512-H/nFsq/FNrYWU6hpuTZHKsJwgDULT+doSchw3j7Il99MdkBKWstxeSBl/GgmsmQHWeGOSIAqeVUS5uqbS32Kkw==",
       "dev": true
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -27677,9 +27677,9 @@
       "dev": true
     },
     "@kosmos/remotestorage-module-kosmos": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@kosmos/remotestorage-module-kosmos/-/remotestorage-module-kosmos-2.1.2.tgz",
-      "integrity": "sha512-aQbQ+qpQnyas54/wRL5aKxlpJV/Alu4yiEv2pc6+lO2acVcR4LlJDkqpXJU93VTvL3li+u3RdwSYbmBaQE7GVg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@kosmos/remotestorage-module-kosmos/-/remotestorage-module-kosmos-2.2.0.tgz",
+      "integrity": "sha512-H/nFsq/FNrYWU6hpuTZHKsJwgDULT+doSchw3j7Il99MdkBKWstxeSBl/GgmsmQHWeGOSIAqeVUS5uqbS32Kkw==",
       "dev": true
     },
     "@nodelib/fs.scandir": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@ember/test-helpers": "^2.2.8",
     "@glimmer/component": "^1.0.3",
     "@glimmer/tracking": "^1.0.4",
-    "@kosmos/remotestorage-module-kosmos": "^2.1.2",
+    "@kosmos/remotestorage-module-kosmos": "^2.2.0",
     "@tailwindcss/forms": "^0.3.3",
     "babel-eslint": "^10.1.0",
     "broccoli-asset-rev": "^3.0.0",


### PR DESCRIPTION
For now, we just assume that all authenticated connections use SASL.

I was able to use this to successfully connect to Libera from my VPN, which they require SASL for. :tada: 

Tested with and depends on https://github.com/sockethub/sockethub/pull/673. Also required adding the `sasl` property to the RS module's schema (already published as 2.2.0).

closes #240