### PR TITLE
Clean up logging service, add storage context

### DIFF
--- a/app/services/logger.js
+++ b/app/services/logger.js
@@ -5,7 +5,6 @@ export default class LoggerService extends Service {
   enabled = true;
 
   allowedTypes = [
-    'connection',
     'error',
     'join',
     'leave',
@@ -13,31 +12,24 @@ export default class LoggerService extends Service {
     'irc_message',
     'xmpp_message',
     'send',
-    'xmpp_completed',
-    'irc_completed',
-    'sh_completed',
-    'sh_failure',
     'irc',
     'xmpp',
     'fetch-error',
-    'chat_message'
+    'chat_message',
+    'storage',
   ];
 
   activeTypes = [
-    'connection',
     'error',
     'join',
     'leave',
     'send',
-    'sh_completed',
-    'xmpp_completed',
-    'irc_completed',
-    'sh_failure',
     'irc',
     'xmpp',
+    'xmpp_message',
     'message',
     'irc_message',
-    'xmpp_message'
+    'storage'
   ];
 
   log (type) {

--- a/app/services/remotestorage.js
+++ b/app/services/remotestorage.js
@@ -1,10 +1,12 @@
-import Service from '@ember/service';
+import Service, { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import RemoteStorage from 'remotestoragejs';
 import Kosmos from '@kosmos/remotestorage-module-kosmos';
 // import config from 'hyperchannel/config/environment';
 
 export default class RemotestorageService extends Service {
+
+  @service logger;
 
   @tracked rsReady = false;
 
@@ -25,25 +27,32 @@ export default class RemotestorageService extends Service {
 
   saveAccount (account) {
     return this.rs.kosmos.accounts.storeConfig(account.serialize())
-      .then(() => console.debug(`saved account ${account.id}`))
+      .then(() => this.log('storage', `saved account ${account.id}`))
       .catch(err => console.error('saving account failed:', err));
   }
 
   removeAccount (account) {
     return this.rs.kosmos.accounts.remove(account.id)
-      .then(() => console.debug(`removed account ${account.id}`));
+      .then(() => this.log('storage', `removed account ${account.id}`));
   }
 
   saveChannel (channel) {
     return this.rs.kosmos.channels.store(channel.serialize())
-      .then(() => console.debug(`saved channel ${channel.id}`))
+      .then(() => this.log('storage', `saved channel ${channel.id}`))
       .catch(err => console.error('saving channel failed:', err));
   }
 
   removeChannel (channel) {
     return this.rs.kosmos.channels.remove(channel.account.id, channel.id)
-      .then(() => console.debug(`removed channel ${channel.id}`))
+      .then(() => this.log('storage', `removed channel ${channel.id}`))
       .catch(err => console.error('removing channel failed:', err));
   }
 
+  /**
+   * Utility function for easier logging
+   * @private
+   */
+  log () {
+    this.logger.log(...arguments);
+  }
 }


### PR DESCRIPTION
Removes obsolete contexts, adds one for storage. RS actions are now logged via the service instead of `console.debug`.