### PR TITLE
Add some configs for better editor/language server support

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -6,5 +6,11 @@
       "hyperchannel/tests/*": ["tests/*"],
       "hyperchannel/*": ["app/*"]
     }
-  }
+  },
+  "exclude": [
+    "dist",
+    "node_modules",
+    "release",
+    "tmp"
+  ]
 }

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,5 +1,10 @@
 {
   "compilerOptions": {
-    "experimentalDecorators": true
+    "experimentalDecorators": true,
+    "baseUrl": ".",
+    "paths": {
+      "hyperchannel/tests/*": ["tests/*"],
+      "hyperchannel/*": ["app/*"]
+    }
   }
 }


### PR DESCRIPTION
This adds mappings for paths to help editors resolve import statements to app and test files

Example:

```js
import Message from 'hyperchannel/models/message';
```

There is no actual `hyperchannel/` folder, those files are located in `app/` instead. This is what the config maps.

It gives us _jump to definition_ and _auto-import_ for functions defined within our own codebase for editors that support this.

Also the `exclude` attribute tells the language service what files are not part of the app's source code. This should help with  performance for IntelliSense/code completion.

After updating to a newer Ember version, we can also include Ember's type packages so we also get auto-import and code completion for Ember itself.