### PR TITLE
Import SockethubClient library as a module

### DIFF
--- a/app/services/sockethub.js
+++ b/app/services/sockethub.js
@@ -28,6 +28,7 @@ export default class SockethubService extends Service {
     return new Promise((resolve, reject) => {
       const script = document.createElement('script');
       document.body.appendChild(script);
+      script.type = "module";
       script.onload = resolve;
       script.onerror = reject;
       script.async = true;


### PR DESCRIPTION
The way bun bundles browser libraries requires the `module` type to be specified.
Related to the fix in:
https://github.com/sockethub/sockethub/pull/899
