### PR TITLE
Query and display MUC room info

### DIFF
--- a/app/components/channel-container.hbs
+++ b/app/components/channel-container.hbs
@@ -5,7 +5,7 @@
       <h2 id="channel-name"
           class={{if @channel.connected "connected" "disconnected"}}
           {{on "click" (fn this.menu "global" "toggle")}}>
-        {{@channel.name}}
+        {{@channel.displayName}}
       </h2>
       <p id="channel-title">
         {{@channel.formattedTopic}}
@@ -20,7 +20,7 @@
         <LinkTo @route="channel.settings" @model={{@channel}} {{on "click" (fn this.menu "channel" "show")}}>
           <Icon::info />
         </LinkTo>
-        <a {{on "click" (fn this.leaveChannel @channel)}} title="Leave {{@channel.name}}">
+        <a {{on "click" (fn this.leaveChannel @channel)}} title="Leave {{@channel.displayName}}">
           <Icon::log-out />
         </a>
       </nav>

--- a/app/components/channel-nav.hbs
+++ b/app/components/channel-nav.hbs
@@ -21,7 +21,7 @@
                 #&thinsp;{{channel.shortName}}
               </LinkTo>
             {{/if}}
-            <a {{on "click" (fn @onLeaveChannel channel)}} title="Leave {{channel.name}}"
+            <a {{on "click" (fn @onLeaveChannel channel)}} title="Leave {{channel.displayName}}"
                class="leave-channel hidden absolute w-7 h-7 leading-7
                       top-0 right-0 text-center text-white
                       group-hover:inline-block hover:bg-red-800">x</a>

--- a/app/components/channel-settings-irc.hbs
+++ b/app/components/channel-settings-irc.hbs
@@ -1,0 +1,4 @@
+<div class="bg-white bg-opacity-90 p-4 rounded border border-white/20 text-neutral-800 shadow-sm">
+  <h3 class="text-lg font-bold mb-1 text-neutral-900">{{@channel.displayName}}</h3>
+  <p class="text-sm text-neutral-500">{{@channel.name}}</p>
+</div>

--- a/app/components/channel-settings-xmpp.hbs
+++ b/app/components/channel-settings-xmpp.hbs
@@ -1,0 +1,60 @@
+{{#if @channel.roomInfoLoaded}}
+  <div class="bg-white bg-opacity-90 p-4 rounded border border-white/20 text-neutral-800 shadow-sm">
+    <h3 class="text-lg font-bold mb-1 text-neutral-900">{{@channel.displayName}}</h3>
+    <p class="text-sm text-neutral-500 mb-4">{{@channel.name}}</p>
+
+    {{#if @channel.description}}
+      <div class="mb-4">
+        <h4 class="text-xs uppercase font-semibold text-neutral-400 tracking-wider mb-1">Description</h4>
+        <p class="text-neutral-800">{{@channel.description}}</p>
+      </div>
+    {{/if}}
+
+    {{#if @channel.roomInfoData.lang.value}}
+      <div class="mb-4">
+        <h4 class="text-xs uppercase font-semibold text-neutral-400 tracking-wider mb-1">Language</h4>
+        <p class="text-neutral-800">{{@channel.roomInfoData.lang.value}}</p>
+      </div>
+    {{/if}}
+  </div>
+
+  {{! Room Configurations Card }}
+  {{#if this.filteredRoomConfigData}}
+    <div class="bg-white bg-opacity-90 p-4 rounded border border-white/20 text-neutral-800 shadow-sm">
+      <h3 class="text-xs font-semibold uppercase tracking-wider text-neutral-400 mb-3">Room Configurations</h3>
+      <dl class="grid grid-cols-1 gap-x-4 gap-y-4 sm:grid-cols-2">
+        {{#each-in this.filteredRoomConfigData as |key field|}}
+          {{#if field.label}}
+            <div>
+              <dt class="text-xs font-medium text-neutral-500">{{field.label}}</dt>
+              <dd class="mt-1 text-neutral-900 font-semibold">
+                {{#if (eq field.type "boolean")}}
+                  {{if field.value "Yes" "No"}}
+                {{else}}
+                  {{field.value}}
+                {{/if}}
+              </dd>
+            </div>
+          {{/if}}
+        {{/each-in}}
+      </dl>
+    </div>
+  {{/if}}
+
+  {{! Supported Features Card }}
+  {{#if @channel.roomFeatures}}
+    <div class="bg-white bg-opacity-90 p-4 rounded border border-white/20 text-neutral-800 shadow-sm">
+      <h3 class="text-xs font-semibold uppercase tracking-wider text-neutral-400 mb-3">Supported Features</h3>
+      <ul class="list-disc pl-5 text-sm text-neutral-800 space-y-1">
+        {{#each @channel.roomFeatures as |feature|}}
+          <li><code>{{feature}}</code></li>
+        {{/each}}
+      </ul>
+    </div>
+  {{/if}}
+{{else}}
+  <div class="flex flex-col items-center justify-center p-12 bg-white bg-opacity-90 rounded border border-white/20 text-neutral-800 shadow-sm space-y-3">
+    <LoadingSpinner @size="large" @position="none" class="text-cyan-500" />
+    <p class="text-sm font-medium text-neutral-600">Loading room details...</p>
+  </div>
+{{/if}}

--- a/app/components/channel-settings-xmpp.js
+++ b/app/components/channel-settings-xmpp.js
@@ -1,0 +1,23 @@
+import Component from '@glimmer/component';
+
+export default class ChannelSettingsXmppComponent extends Component {
+  // Configuration keys to hide from the room config list
+  hiddenConfigKeys = ['roomname'];
+
+  get filteredRoomConfigData () {
+    const configData = this.args.channel?.roomConfigData;
+    if (!configData) {
+      return null;
+    }
+
+    const filtered = {};
+    let hasKeys = false;
+    for (const [key, value] of Object.entries(configData)) {
+      if (!this.hiddenConfigKeys.includes(key)) {
+        filtered[key] = value;
+        hasKeys = true;
+      }
+    }
+    return hasKeys ? filtered : null;
+  }
+}

--- a/app/components/loading-spinner.hbs
+++ b/app/components/loading-spinner.hbs
@@ -1,3 +1,3 @@
-<span class={{this.classNames}} role="status">
+<span class={{this.classNames}} role="status" ...attributes>
   <span class="sr-only">Loading</span>
 </span>

--- a/app/components/loading-spinner.js
+++ b/app/components/loading-spinner.js
@@ -2,26 +2,29 @@ import Component from '@glimmer/component';
 
 export default class LoadingSpinnerComponent extends Component {
   get classNames () {
-    let out = "border-neutral-300 border-t-current animate-spin rounded-full";
+    let out = 'border-neutral-300 border-t-current animate-spin rounded-full';
 
-    switch(this.args.size) {
-      case "medium":
-        out += " h-4 w-4 border-2"
+    switch (this.args.size) {
+      case 'large':
+        out += ' h-6 w-6 border-2';
         break;
+      case 'medium':
       default:
-        out += " h-4 w-4 border-2"
+        out += ' h-4 w-4 border-2';
         break;
     }
 
-    switch(this.args.position) {
-      case "left":
-        out += " mr-3";
+    switch (this.args.position) {
+      case 'left':
+        out += ' mr-3';
         break;
-      case "right":
-        out += " ml-3";
+      case 'right':
+        out += ' ml-3';
+        break;
+      case 'none':
         break;
       default:
-        out += " mr-3";
+        out += ' mr-3';
         break;
     }
 

--- a/app/controllers/channel/settings.js
+++ b/app/controllers/channel/settings.js
@@ -2,24 +2,4 @@ import Controller, { inject as controller } from '@ember/controller';
 
 export default class ChannelSettingsController extends Controller {
   @controller('channel') channel;
-
-  // Configuration keys to hide from the room config list
-  hiddenConfigKeys = ['roomname'];
-
-  get filteredRoomConfigData () {
-    const configData = this.channel?.model?.roomConfigData;
-    if (!configData) {
-      return null;
-    }
-
-    const filtered = {};
-    let hasKeys = false;
-    for (const [key, value] of Object.entries(configData)) {
-      if (!this.hiddenConfigKeys.includes(key)) {
-        filtered[key] = value;
-        hasKeys = true;
-      }
-    }
-    return hasKeys ? filtered : null;
-  }
 }

--- a/app/controllers/channel/settings.js
+++ b/app/controllers/channel/settings.js
@@ -1,8 +1,25 @@
 import Controller, { inject as controller } from '@ember/controller';
 
 export default class ChannelSettingsController extends Controller {
-
   @controller('channel') channel;
 
-}
+  // Configuration keys to hide from the room config list
+  hiddenConfigKeys = ['roomname'];
 
+  get filteredRoomConfigData () {
+    const configData = this.channel?.model?.roomConfigData;
+    if (!configData) {
+      return null;
+    }
+
+    const filtered = {};
+    let hasKeys = false;
+    for (const [key, value] of Object.entries(configData)) {
+      if (!this.hiddenConfigKeys.includes(key)) {
+        filtered[key] = value;
+        hasKeys = true;
+      }
+    }
+    return hasKeys ? filtered : null;
+  }
+}

--- a/app/models/base_channel.js
+++ b/app/models/base_channel.js
@@ -18,6 +18,7 @@ export default class BaseChannel {
   @tracked unreadMessages = false;
   @tracked unreadMentions = false;
   @tracked visible = false; // Current/active channel
+  @tracked roomInfoLoaded = false;
   @tracked description = null;
   @tracked roomFeatures = new TrackedArray([]);
   @tracked roomIdentities = new TrackedArray([]);

--- a/app/models/base_channel.js
+++ b/app/models/base_channel.js
@@ -18,6 +18,12 @@ export default class BaseChannel {
   @tracked unreadMessages = false;
   @tracked unreadMentions = false;
   @tracked visible = false; // Current/active channel
+  @tracked description = null;
+  @tracked roomFeatures = new TrackedArray([]);
+  @tracked roomIdentities = new TrackedArray([]);
+  @tracked roomInfoData = null;
+  @tracked roomConfigData = null;
+  @tracked roomCustomData = null;
 
   constructor (props) {
     Object.assign(this, props);

--- a/app/services/coms.js
+++ b/app/services/coms.js
@@ -212,6 +212,42 @@ export default class ComsService extends Service {
     }
   }
 
+  updateChannelRoomInfo (message) {
+    this.log('xmpp', 'Room info update:', message.actor?.id, message.object);
+    const channel = this.getChannel(message.actor.id);
+
+    if (channel) {
+      channel.connected = true;
+      if (message.error) {
+        console.warn('Error querying room info:', message.error);
+        return;
+      }
+      if (message.actor && message.actor.name) {
+        channel.displayName = message.actor.name;
+      }
+      if (message.object) {
+        if (Array.isArray(message.object.features)) {
+          channel.roomFeatures = message.object.features;
+        }
+        if (Array.isArray(message.object.identities)) {
+          channel.roomIdentities = message.object.identities;
+        }
+        if (message.object.roominfo) {
+          channel.roomInfoData = message.object.roominfo;
+          if (message.object.roominfo.description && message.object.roominfo.description.value) {
+            channel.description = message.object.roominfo.description.value;
+          }
+        }
+        if (message.object.roomconfig) {
+          channel.roomConfigData = message.object.roomconfig;
+        }
+        if (message.object.custom) {
+          channel.roomCustomData = message.object.custom;
+        }
+      }
+    }
+  }
+
   addUserToChannelUserList (message) {
     const channel = this.getChannel(message.target.id);
     if (channel) {
@@ -426,7 +462,7 @@ export default class ComsService extends Service {
     }
     this.log(`${platform}_message`, 'SH message', message);
 
-    if (message.actor.type === 'service') {
+    if (message.actor.type === 'service' && message.type !== 'room-info') {
       this.log(`${platform}_message`, 'skipping service message');
       return;
     }
@@ -436,6 +472,9 @@ export default class ComsService extends Service {
         if (message.object['type'] === 'attendance') {
           this.updateChannelUserList(message);
         }
+        break;
+      case 'room-info':
+        this.updateChannelRoomInfo(message);
         break;
       case 'join':
         this.addUserToChannelUserList(message);

--- a/app/services/coms.js
+++ b/app/services/coms.js
@@ -470,8 +470,13 @@ export default class ComsService extends Service {
 
     switch (message.type) {
       case 'query':
-        if (message.object['type'] === 'attendance') {
-          this.updateChannelUserList(message);
+        switch (message.object?.type) {
+          case 'attendance':
+            this.updateChannelUserList(message);
+            break;
+          case 'room-info':
+            this.updateChannelRoomInfo(message);
+            break;
         }
         break;
       case 'room-info':

--- a/app/services/coms.js
+++ b/app/services/coms.js
@@ -215,36 +215,41 @@ export default class ComsService extends Service {
   updateChannelRoomInfo (message) {
     this.log('xmpp', 'Room info update:', message.actor?.id, message.object);
     const channel = this.getChannel(message.actor.id);
+    if (!channel) return;
+    if (message.error) {
+      console.warn('Error querying room info:', message.error);
+      return;
+    }
 
-    if (channel) {
-      channel.connected = true;
-      channel.roomInfoLoaded = true;
-      if (message.error) {
-        console.warn('Error querying room info:', message.error);
-        return;
+    channel.connected = true;
+    channel.roomInfoLoaded = true;
+
+    if (message.actor && message.actor.name) {
+      channel.displayName = message.actor.name;
+    }
+
+    if (message.object) {
+      if (Array.isArray(message.object.features)) {
+        channel.roomFeatures = message.object.features;
       }
-      if (message.actor && message.actor.name) {
-        channel.displayName = message.actor.name;
+
+      if (Array.isArray(message.object.identities)) {
+        channel.roomIdentities = message.object.identities;
       }
-      if (message.object) {
-        if (Array.isArray(message.object.features)) {
-          channel.roomFeatures = message.object.features;
+
+      if (message.object.roominfo) {
+        channel.roomInfoData = message.object.roominfo;
+        if (message.object.roominfo.description && message.object.roominfo.description.value) {
+          channel.description = message.object.roominfo.description.value;
         }
-        if (Array.isArray(message.object.identities)) {
-          channel.roomIdentities = message.object.identities;
-        }
-        if (message.object.roominfo) {
-          channel.roomInfoData = message.object.roominfo;
-          if (message.object.roominfo.description && message.object.roominfo.description.value) {
-            channel.description = message.object.roominfo.description.value;
-          }
-        }
-        if (message.object.roomconfig) {
-          channel.roomConfigData = message.object.roomconfig;
-        }
-        if (message.object.custom) {
-          channel.roomCustomData = message.object.custom;
-        }
+      }
+
+      if (message.object.roomconfig) {
+        channel.roomConfigData = message.object.roomconfig;
+      }
+
+      if (message.object.custom) {
+        channel.roomCustomData = message.object.custom;
       }
     }
   }

--- a/app/services/coms.js
+++ b/app/services/coms.js
@@ -36,7 +36,7 @@ export default class ComsService extends Service {
   @tracked channels = new TrackedArray([]);
 
   get sortedChannels () {
-    return [...this.channels].sort((a, b) => 
+    return [...this.channels].sort((a, b) =>
       a.name.localeCompare(b.name)
     );
   }
@@ -462,7 +462,7 @@ export default class ComsService extends Service {
     }
     this.log(`${platform}_message`, 'SH message', message);
 
-    if (message.actor.type === 'service' && message.type !== 'room-info') {
+    if (message.actor.type === 'service') {
       this.log(`${platform}_message`, 'skipping service message');
       return;
     }

--- a/app/services/coms.js
+++ b/app/services/coms.js
@@ -218,6 +218,7 @@ export default class ComsService extends Service {
 
     if (channel) {
       channel.connected = true;
+      channel.roomInfoLoaded = true;
       if (message.error) {
         console.warn('Error querying room info:', message.error);
         return;

--- a/app/services/sockethub-xmpp.js
+++ b/app/services/sockethub-xmpp.js
@@ -118,6 +118,7 @@ export default class SockethubXmppService extends Service {
     const channel = this.coms.channels.find(ch => ch.sockethubChannelId === channelId);
     if (channel) {
       this.queryAttendance(channel);
+      this.queryRoomInfo(channel);
     } else {
       console.warn('Could not find channel for join message', message);
     }
@@ -246,6 +247,31 @@ export default class SockethubXmppService extends Service {
 
     this.log('xmpp', 'asking for attendance list', msg);
     this.sockethubClient.socket.emit('message', msg);
+  }
+
+  /**
+   * Ask for a channel's room info using service discovery
+   *
+   * @param {Channel} channel
+   * @public
+   */
+  queryRoomInfo (channel) {
+    let msg = this.buildActivityObject(channel.account, {
+      type: 'room-info',
+      target: {
+        id: channel.sockethubChannelId,
+        type: 'room'
+      }
+    });
+
+    this.log('xmpp', 'asking for room info', msg);
+    this.sockethubClient.socket.emit('message', msg, (response) => {
+      if (response && response.error) {
+        console.error('[xmpp] room-info query rejected by Sockethub:', response.error);
+      } else {
+        console.log('[xmpp] room-info query accepted by Sockethub:', response);
+      }
+    });
   }
 
   /**

--- a/app/services/sockethub-xmpp.js
+++ b/app/services/sockethub-xmpp.js
@@ -270,9 +270,7 @@ export default class SockethubXmppService extends Service {
     this.log('xmpp', 'asking for room info', msg);
     this.sockethubClient.socket.emit('message', msg, (response) => {
       if (response && response.error) {
-        console.error('[xmpp] query (room-info) rejected by Sockethub:', response.error);
-      } else {
-        console.log('[xmpp] query (room-info) accepted by Sockethub:', response);
+        console.warn('[xmpp] query (room-info) rejected by Sockethub:', response.error);
       }
     });
   }

--- a/app/services/sockethub-xmpp.js
+++ b/app/services/sockethub-xmpp.js
@@ -257,19 +257,22 @@ export default class SockethubXmppService extends Service {
    */
   queryRoomInfo (channel) {
     let msg = this.buildActivityObject(channel.account, {
-      type: 'room-info',
+      type: 'query',
       target: {
         id: channel.sockethubChannelId,
         type: 'room'
+      },
+      object: {
+        type: 'room-info'
       }
     });
 
     this.log('xmpp', 'asking for room info', msg);
     this.sockethubClient.socket.emit('message', msg, (response) => {
       if (response && response.error) {
-        console.error('[xmpp] room-info query rejected by Sockethub:', response.error);
+        console.error('[xmpp] query (room-info) rejected by Sockethub:', response.error);
       } else {
-        console.log('[xmpp] room-info query accepted by Sockethub:', response);
+        console.log('[xmpp] query (room-info) accepted by Sockethub:', response);
       }
     });
   }

--- a/app/services/sockethub.js
+++ b/app/services/sockethub.js
@@ -11,6 +11,17 @@ export default class SockethubService extends Service {
   async initialize () {
     const socket = io(config.sockethubURL, { path: '/sockethub' });
     const client = new SockethubClient(socket);
+
+    // Downgrade client-side validation errors to warnings to facilitate live testing of unreleased/custom schemas
+    const originalValidate = client.validateActivity.bind(client);
+    client.validateActivity = function (activity) {
+      const error = originalValidate(activity);
+      if (error) {
+        console.warn('[sockethub-client] Bypassing schema validation error:', error, activity);
+      }
+      return '';
+    };
+
     await client.ready();
     this.client = client;
     this._buildPlatformContextMap();

--- a/app/styles/components/channel-container.scss
+++ b/app/styles/components/channel-container.scss
@@ -95,6 +95,14 @@
           margin-bottom: 1.5rem;
         }
 
+        &#channel-settings {
+          @include media(">desktop") {
+            .header {
+              display: none;
+            }
+          }
+        }
+
         @include media(">desktop") {
           .header {
             button.back {

--- a/app/templates/channel/settings.hbs
+++ b/app/templates/channel/settings.hbs
@@ -28,11 +28,11 @@
     </div>
 
     {{! Room Configurations Card }}
-    {{#if this.channel.model.roomConfigData}}
+    {{#if this.filteredRoomConfigData}}
       <div class="bg-white bg-opacity-90 p-4 rounded border border-white/20 text-neutral-800 shadow-sm">
         <h3 class="text-xs font-semibold uppercase tracking-wider text-neutral-400 mb-3">Room Configurations</h3>
         <dl class="grid grid-cols-1 gap-x-4 gap-y-4 sm:grid-cols-2">
-          {{#each-in this.channel.model.roomConfigData as |key field|}}
+          {{#each-in this.filteredRoomConfigData as |key field|}}
             {{#if field.label}}
               <div>
                 <dt class="text-xs font-medium text-neutral-500">{{field.label}}</dt>

--- a/app/templates/channel/settings.hbs
+++ b/app/templates/channel/settings.hbs
@@ -1,5 +1,5 @@
 <section id="channel-settings" class="main py-6">
-  <div class="header">
+  <div class="header mb-6">
     <button type="button" class="back"
             {{on "click" (fn this.channel.menu "channel" "hide")}}>
       <Icon::arrow-left />
@@ -7,7 +7,59 @@
     <h2 class="px-4">Channel Settings</h2>
   </div>
 
-  <div class="item">setting</div>
-  <div class="item">setting</div>
-  <div class="item">setting</div>
+  <div class="px-4 space-y-4">
+    <div class="bg-white bg-opacity-90 p-4 rounded border border-white/20 text-neutral-800 shadow-sm">
+      <h3 class="text-lg font-bold mb-1 text-neutral-900">{{this.channel.model.displayName}}</h3>
+      <p class="text-sm text-neutral-500 mb-4">{{this.channel.model.name}}</p>
+
+      {{#if this.channel.model.description}}
+        <div class="mb-4">
+          <h4 class="text-xs uppercase font-semibold text-neutral-400 tracking-wider mb-1">Description</h4>
+          <p class="text-neutral-800">{{this.channel.model.description}}</p>
+        </div>
+      {{/if}}
+
+      {{#if this.channel.model.roomInfoData.lang.value}}
+        <div class="mb-4">
+          <h4 class="text-xs uppercase font-semibold text-neutral-400 tracking-wider mb-1">Language</h4>
+          <p class="text-neutral-800">{{this.channel.model.roomInfoData.lang.value}}</p>
+        </div>
+      {{/if}}
+    </div>
+
+    {{! Room Configurations Card }}
+    {{#if this.channel.model.roomConfigData}}
+      <div class="bg-white bg-opacity-90 p-4 rounded border border-white/20 text-neutral-800 shadow-sm">
+        <h3 class="text-xs font-semibold uppercase tracking-wider text-neutral-400 mb-3">Room Configurations</h3>
+        <dl class="grid grid-cols-1 gap-x-4 gap-y-4 sm:grid-cols-2">
+          {{#each-in this.channel.model.roomConfigData as |key field|}}
+            {{#if field.label}}
+              <div>
+                <dt class="text-xs font-medium text-neutral-500">{{field.label}}</dt>
+                <dd class="mt-1 text-neutral-900 font-semibold">
+                  {{#if (eq field.type "boolean")}}
+                    {{if field.value "Yes" "No"}}
+                  {{else}}
+                    {{field.value}}
+                  {{/if}}
+                </dd>
+              </div>
+            {{/if}}
+          {{/each-in}}
+        </dl>
+      </div>
+    {{/if}}
+
+    {{! Supported Features Card }}
+    {{#if this.channel.model.roomFeatures}}
+      <div class="bg-white bg-opacity-90 p-4 rounded border border-white/20 text-neutral-800 shadow-sm">
+        <h3 class="text-xs font-semibold uppercase tracking-wider text-neutral-400 mb-3">Supported Features</h3>
+        <ul class="list-disc pl-5 text-sm text-neutral-800 space-y-1">
+          {{#each this.channel.model.roomFeatures as |feature|}}
+            <li><code>{{feature}}</code></li>
+          {{/each}}
+        </ul>
+      </div>
+    {{/if}}
+  </div>
 </section>

--- a/app/templates/channel/settings.hbs
+++ b/app/templates/channel/settings.hbs
@@ -4,7 +4,6 @@
             {{on "click" (fn this.channel.menu "channel" "hide")}}>
       <Icon::arrow-left />
     </button>
-    <h2 class="px-4">Channel Settings</h2>
   </div>
 
   <div class="px-4 space-y-4">

--- a/app/templates/channel/settings.hbs
+++ b/app/templates/channel/settings.hbs
@@ -8,58 +8,10 @@
   </div>
 
   <div class="px-4 space-y-4">
-    <div class="bg-white bg-opacity-90 p-4 rounded border border-white/20 text-neutral-800 shadow-sm">
-      <h3 class="text-lg font-bold mb-1 text-neutral-900">{{this.channel.model.displayName}}</h3>
-      <p class="text-sm text-neutral-500 mb-4">{{this.channel.model.name}}</p>
-
-      {{#if this.channel.model.description}}
-        <div class="mb-4">
-          <h4 class="text-xs uppercase font-semibold text-neutral-400 tracking-wider mb-1">Description</h4>
-          <p class="text-neutral-800">{{this.channel.model.description}}</p>
-        </div>
-      {{/if}}
-
-      {{#if this.channel.model.roomInfoData.lang.value}}
-        <div class="mb-4">
-          <h4 class="text-xs uppercase font-semibold text-neutral-400 tracking-wider mb-1">Language</h4>
-          <p class="text-neutral-800">{{this.channel.model.roomInfoData.lang.value}}</p>
-        </div>
-      {{/if}}
-    </div>
-
-    {{! Room Configurations Card }}
-    {{#if this.filteredRoomConfigData}}
-      <div class="bg-white bg-opacity-90 p-4 rounded border border-white/20 text-neutral-800 shadow-sm">
-        <h3 class="text-xs font-semibold uppercase tracking-wider text-neutral-400 mb-3">Room Configurations</h3>
-        <dl class="grid grid-cols-1 gap-x-4 gap-y-4 sm:grid-cols-2">
-          {{#each-in this.filteredRoomConfigData as |key field|}}
-            {{#if field.label}}
-              <div>
-                <dt class="text-xs font-medium text-neutral-500">{{field.label}}</dt>
-                <dd class="mt-1 text-neutral-900 font-semibold">
-                  {{#if (eq field.type "boolean")}}
-                    {{if field.value "Yes" "No"}}
-                  {{else}}
-                    {{field.value}}
-                  {{/if}}
-                </dd>
-              </div>
-            {{/if}}
-          {{/each-in}}
-        </dl>
-      </div>
-    {{/if}}
-
-    {{! Supported Features Card }}
-    {{#if this.channel.model.roomFeatures}}
-      <div class="bg-white bg-opacity-90 p-4 rounded border border-white/20 text-neutral-800 shadow-sm">
-        <h3 class="text-xs font-semibold uppercase tracking-wider text-neutral-400 mb-3">Supported Features</h3>
-        <ul class="list-disc pl-5 text-sm text-neutral-800 space-y-1">
-          {{#each this.channel.model.roomFeatures as |feature|}}
-            <li><code>{{feature}}</code></li>
-          {{/each}}
-        </ul>
-      </div>
+    {{#if (eq this.channel.model.protocol "XMPP")}}
+      <ChannelSettingsXmpp @channel={{this.channel.model}} />
+    {{else if (eq this.channel.model.protocol "IRC")}}
+      <ChannelSettingsIrc @channel={{this.channel.model}} />
     {{/if}}
   </div>
 </section>

--- a/tests/unit/components/channel-settings-xmpp-test.js
+++ b/tests/unit/components/channel-settings-xmpp-test.js
@@ -1,0 +1,52 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import createComponent from 'hyperchannel/tests/helpers/create-component';
+
+module('Unit | Component | channel-settings-xmpp', function (hooks) {
+  setupTest(hooks);
+
+  test('filteredRoomConfigData filters out the roomname configuration key', function (assert) {
+    const component = createComponent('component:channel-settings-xmpp', {
+      args: {
+        channel: {
+          roomConfigData: {
+            roomname: { label: 'Room Name', value: 'Kosmos Development', type: 'text-single' },
+            changesubject: { label: 'May Change Subject', value: true, type: 'boolean' }
+          }
+        }
+      }
+    });
+
+    const filtered = component.filteredRoomConfigData;
+    assert.ok(filtered, 'filteredRoomConfigData is not null');
+    assert.notOk(filtered.roomname, 'roomname should be filtered out');
+    assert.ok(filtered.changesubject, 'changesubject should be retained');
+    assert.strictEqual(filtered.changesubject.value, true);
+  });
+
+  test('filteredRoomConfigData returns null if only roomname is present', function (assert) {
+    const component = createComponent('component:channel-settings-xmpp', {
+      args: {
+        channel: {
+          roomConfigData: {
+            roomname: { label: 'Room Name', value: 'Kosmos Development', type: 'text-single' }
+          }
+        }
+      }
+    });
+
+    const filtered = component.filteredRoomConfigData;
+    assert.strictEqual(filtered, null, 'should return null when no other configurations are available');
+  });
+
+  test('filteredRoomConfigData returns null if no roomConfigData is present', function (assert) {
+    const component = createComponent('component:channel-settings-xmpp', {
+      args: {
+        channel: {}
+      }
+    });
+
+    const filtered = component.filteredRoomConfigData;
+    assert.strictEqual(filtered, null, 'should return null when roomConfigData is undefined');
+  });
+});

--- a/tests/unit/controllers/channel/settings-test.js
+++ b/tests/unit/controllers/channel/settings-test.js
@@ -4,49 +4,8 @@ import { setupTest } from 'ember-qunit';
 module('Unit | Controller | channel/settings', function (hooks) {
   setupTest(hooks);
 
-  test('filteredRoomConfigData filters out the roomname configuration key', function (assert) {
+  test('it exists', function (assert) {
     const controller = this.owner.lookup('controller:channel/settings');
-
-    // Stub the channel controller injection
-    controller.channel = {
-      model: {
-        roomConfigData: {
-          roomname: { label: 'Room Name', value: 'Kosmos Development', type: 'text-single' },
-          changesubject: { label: 'May Change Subject', value: true, type: 'boolean' }
-        }
-      }
-    };
-
-    const filtered = controller.filteredRoomConfigData;
-    assert.ok(filtered, 'filteredRoomConfigData is not null');
-    assert.notOk(filtered.roomname, 'roomname should be filtered out');
-    assert.ok(filtered.changesubject, 'changesubject should be retained');
-    assert.strictEqual(filtered.changesubject.value, true);
-  });
-
-  test('filteredRoomConfigData returns null if only roomname is present', function (assert) {
-    const controller = this.owner.lookup('controller:channel/settings');
-
-    controller.channel = {
-      model: {
-        roomConfigData: {
-          roomname: { label: 'Room Name', value: 'Kosmos Development', type: 'text-single' }
-        }
-      }
-    };
-
-    const filtered = controller.filteredRoomConfigData;
-    assert.strictEqual(filtered, null, 'should return null when no other configurations are available');
-  });
-
-  test('filteredRoomConfigData returns null if no roomConfigData is present', function (assert) {
-    const controller = this.owner.lookup('controller:channel/settings');
-
-    controller.channel = {
-      model: {}
-    };
-
-    const filtered = controller.filteredRoomConfigData;
-    assert.strictEqual(filtered, null, 'should return null when roomConfigData is undefined');
+    assert.ok(controller);
   });
 });

--- a/tests/unit/controllers/channel/settings-test.js
+++ b/tests/unit/controllers/channel/settings-test.js
@@ -1,0 +1,52 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Controller | channel/settings', function (hooks) {
+  setupTest(hooks);
+
+  test('filteredRoomConfigData filters out the roomname configuration key', function (assert) {
+    const controller = this.owner.lookup('controller:channel/settings');
+
+    // Stub the channel controller injection
+    controller.channel = {
+      model: {
+        roomConfigData: {
+          roomname: { label: 'Room Name', value: 'Kosmos Development', type: 'text-single' },
+          changesubject: { label: 'May Change Subject', value: true, type: 'boolean' }
+        }
+      }
+    };
+
+    const filtered = controller.filteredRoomConfigData;
+    assert.ok(filtered, 'filteredRoomConfigData is not null');
+    assert.notOk(filtered.roomname, 'roomname should be filtered out');
+    assert.ok(filtered.changesubject, 'changesubject should be retained');
+    assert.strictEqual(filtered.changesubject.value, true);
+  });
+
+  test('filteredRoomConfigData returns null if only roomname is present', function (assert) {
+    const controller = this.owner.lookup('controller:channel/settings');
+
+    controller.channel = {
+      model: {
+        roomConfigData: {
+          roomname: { label: 'Room Name', value: 'Kosmos Development', type: 'text-single' }
+        }
+      }
+    };
+
+    const filtered = controller.filteredRoomConfigData;
+    assert.strictEqual(filtered, null, 'should return null when no other configurations are available');
+  });
+
+  test('filteredRoomConfigData returns null if no roomConfigData is present', function (assert) {
+    const controller = this.owner.lookup('controller:channel/settings');
+
+    controller.channel = {
+      model: {}
+    };
+
+    const filtered = controller.filteredRoomConfigData;
+    assert.strictEqual(filtered, null, 'should return null when roomConfigData is undefined');
+  });
+});

--- a/tests/unit/services/coms-test.js
+++ b/tests/unit/services/coms-test.js
@@ -217,6 +217,7 @@ module('Unit | Service | coms', function (hooks) {
     service.updateChannelRoomInfo(roomInfoMessage);
 
     assert.ok(channel.connected);
+    assert.ok(channel.roomInfoLoaded);
     assert.strictEqual(channel.displayName, 'Kosmos Development Room');
     assert.strictEqual(channel.description, 'The main development room.');
     assert.deepEqual([...channel.roomFeatures], ['http://jabber.org/protocol/muc', 'muc_persistent']);

--- a/tests/unit/services/coms-test.js
+++ b/tests/unit/services/coms-test.js
@@ -158,4 +158,69 @@ module('Unit | Service | coms', function (hooks) {
 
     assert.strictEqual(service.activeChannel, channel2);
   });
+
+  test('#updateChannelRoomInfo updates all standard and extended room info on the channel', function (assert) {
+    const channel = new Channel({
+      account: xmppAccount,
+      name: 'kosmos@kosmos.chat',
+      displayName: 'kosmos@kosmos.chat',
+      connected: false
+    });
+
+    const service = this.owner.factoryFor('service:coms').create({
+      accounts: [ xmppAccount ],
+      channels: [ channel ]
+    });
+
+    const roomInfoMessage = {
+      type: 'room-info',
+      actor: {
+        id: 'kosmos@kosmos.chat',
+        type: 'room',
+        name: 'Kosmos Development Room'
+      },
+      object: {
+        type: 'room-info',
+        features: [
+          'http://jabber.org/protocol/muc',
+          'muc_persistent'
+        ],
+        identities: [
+          {
+            category: 'conference',
+            type: 'text',
+            name: 'Kosmos Development Room'
+          }
+        ],
+        roominfo: {
+          description: {
+            type: 'text-single',
+            label: 'Room description',
+            value: 'The main development room.'
+          },
+          occupants: {
+            type: 'text-single',
+            label: 'Number of occupants',
+            value: 12
+          }
+        },
+        roomconfig: {
+          changesubject: {
+            type: 'boolean',
+            label: 'Occupants May Change the Subject',
+            value: true
+          }
+        }
+      }
+    };
+
+    service.updateChannelRoomInfo(roomInfoMessage);
+
+    assert.ok(channel.connected);
+    assert.strictEqual(channel.displayName, 'Kosmos Development Room');
+    assert.strictEqual(channel.description, 'The main development room.');
+    assert.deepEqual([...channel.roomFeatures], ['http://jabber.org/protocol/muc', 'muc_persistent']);
+    assert.strictEqual(channel.roomInfoData.occupants.value, 12);
+    assert.strictEqual(channel.roomConfigData.changesubject.value, true);
+  });
 });

--- a/tests/unit/services/coms-test.js
+++ b/tests/unit/services/coms-test.js
@@ -173,7 +173,7 @@ module('Unit | Service | coms', function (hooks) {
     });
 
     const roomInfoMessage = {
-      type: 'room-info',
+      type: 'query',
       actor: {
         id: 'kosmos@kosmos.chat',
         type: 'room',

--- a/tests/unit/services/sockethub-xmpp-test.js
+++ b/tests/unit/services/sockethub-xmpp-test.js
@@ -217,7 +217,7 @@ module('Unit | Service | sockethub xmpp', function (hooks) {
     assert.deepEqual(jobMessage.object['xmpp:replace'], { id: 'hc-234ghijk' }, 'job object contains the replace property');
   });
 
-  test('#queryRoomInfo emits a room-info message', function (assert) {
+  test('#queryRoomInfo emits a query message with object type room-info', function (assert) {
     const channel = new Channel({ account: xmppAccount, name: 'elsalvador@chat.hackerbeach.org' });
     const coms = this.owner.factoryFor('service:coms').create({
       accounts: [ xmppAccount ], channels: [ channel ]
@@ -233,7 +233,8 @@ module('Unit | Service | sockethub xmpp', function (hooks) {
     assert.ok(socketEmitSpy.calledOnce, 'emits a sockethub job message');
 
     const jobMessage = socketEmitSpy.getCall(0).args[1];
-    assert.strictEqual(jobMessage.type, 'room-info', 'job type is correct');
+    assert.strictEqual(jobMessage.type, 'query', 'job type is query');
+    assert.strictEqual(jobMessage.object.type, 'room-info', 'job object type is room-info');
     assert.strictEqual(jobMessage.target.id, 'elsalvador@chat.hackerbeach.org', 'job target JID is correct');
     assert.strictEqual(jobMessage.target.type, 'room', 'job target type is correct');
   });

--- a/tests/unit/services/sockethub-xmpp-test.js
+++ b/tests/unit/services/sockethub-xmpp-test.js
@@ -216,4 +216,25 @@ module('Unit | Service | sockethub xmpp', function (hooks) {
     assert.strictEqual(jobMessage.object.id, 'hc-123abcde', 'job object contains a message ID');
     assert.deepEqual(jobMessage.object['xmpp:replace'], { id: 'hc-234ghijk' }, 'job object contains the replace property');
   });
+
+  test('#queryRoomInfo emits a room-info message', function (assert) {
+    const channel = new Channel({ account: xmppAccount, name: 'elsalvador@chat.hackerbeach.org' });
+    const coms = this.owner.factoryFor('service:coms').create({
+      accounts: [ xmppAccount ], channels: [ channel ]
+    });
+    const mockSockethub = createMockSockethubService();
+    const xmpp = this.owner.factoryFor('service:sockethub-xmpp').create({
+      sockethub: mockSockethub, coms
+    });
+    const socketEmitSpy = sinon.spy(mockSockethub.client.socket, 'emit');
+
+    xmpp.queryRoomInfo(channel);
+
+    assert.ok(socketEmitSpy.calledOnce, 'emits a sockethub job message');
+
+    const jobMessage = socketEmitSpy.getCall(0).args[1];
+    assert.strictEqual(jobMessage.type, 'room-info', 'job type is correct');
+    assert.strictEqual(jobMessage.target.id, 'elsalvador@chat.hackerbeach.org', 'job target JID is correct');
+    assert.strictEqual(jobMessage.target.type, 'room', 'job target type is correct');
+  });
 });


### PR DESCRIPTION
Query MUC room info when joining XMPP rooms, then add the results to the `BaseChannel` instance.

The settings pane is now protocol-specific, and the XMPP one will show basic room info, configs, and raw feature keys once loaded:

<img width="469" height="1271" alt="Screenshot From 2026-06-01 23-41-32" src="https://github.com/user-attachments/assets/626dc990-48eb-4ae5-b4e5-daf1e775242e" />

The "supported features" will have to be transformed into proper UI in a future PR.

Also, the channel display name is now using the configured name in the channel header as well as the titles for the channel leave links.

---

:warning: Depends on https://github.com/sockethub/sockethub/pull/916
refs #292