### PR TITLE
Load sockethub client bundle from server at runtime

### DIFF
--- a/app/services/sockethub.js
+++ b/app/services/sockethub.js
@@ -7,26 +7,27 @@ export default class SockethubService extends Service {
   _platformContextMap = new Map();
 
   async initialize () {
-    await this._loadSockethubLibs();
-    const socket = window.io(config.sockethubURL, { path: '/sockethub' });
-    const client = new window.SockethubClient(socket);
-    await client.ready();
-    this.client = client;
-    this._buildPlatformContextMap();
+    return this.loadSockethubLibs(config.sockethubURL).then(async () => {
+      const socket = window.io(config.sockethubURL, { path: '/sockethub' });
+      const client = new window.SockethubClient(socket);
+      await client.ready();
+      this.client = client;
+      this._buildPlatformContextMap();
+    });
   }
 
-  async _loadSockethubLibs () {
-    await this._loadExternalScript(`${config.sockethubURL}/socket.io.js`);
-    await this._loadExternalScript(`${config.sockethubURL}/sockethub-client.js`);
+  async loadSockethubLibs (baseURL) {
+    await this.loadExternalScript(baseURL + '/socket.io.js');
+    await this.loadExternalScript(baseURL + '/sockethub-client.js');
   }
 
-  _loadExternalScript (url) {
+  async loadExternalScript (url) {
     return new Promise((resolve, reject) => {
       const script = document.createElement('script');
       document.body.appendChild(script);
       script.type = 'module';
       script.onload = resolve;
-      script.onerror = () => reject(new Error(`Failed to load script from ${url}`));
+      script.onerror = reject;
       script.async = true;
       script.src = url;
     });

--- a/app/services/sockethub.js
+++ b/app/services/sockethub.js
@@ -1,6 +1,5 @@
 import Service from '@ember/service';
 import { tracked } from '@glimmer/tracking';
-import { io } from 'socket.io-client';
 import config from 'hyperchannel/config/environment';
 
 export default class SockethubService extends Service {
@@ -8,21 +7,28 @@ export default class SockethubService extends Service {
   _platformContextMap = new Map();
 
   async initialize () {
-    await this._loadClientScript();
-    const socket = io(config.sockethubURL, { path: '/sockethub' });
+    await this._loadSockethubLibs();
+    const socket = window.io(config.sockethubURL, { path: '/sockethub' });
     const client = new window.SockethubClient(socket);
     await client.ready();
     this.client = client;
     this._buildPlatformContextMap();
   }
 
-  _loadClientScript () {
+  async _loadSockethubLibs () {
+    await this._loadExternalScript(`${config.sockethubURL}/socket.io.js`);
+    await this._loadExternalScript(`${config.sockethubURL}/sockethub-client.js`);
+  }
+
+  _loadExternalScript (url) {
     return new Promise((resolve, reject) => {
       const script = document.createElement('script');
-      script.src = `${config.sockethubURL}/sockethub-client.js`;
+      document.body.appendChild(script);
+      script.type = 'module';
       script.onload = resolve;
-      script.onerror = () => reject(new Error(`Failed to load sockethub client from ${script.src}`));
-      document.head.appendChild(script);
+      script.onerror = () => reject(new Error(`Failed to load script from ${url}`));
+      script.async = true;
+      script.src = url;
     });
   }
 

--- a/app/services/sockethub.js
+++ b/app/services/sockethub.js
@@ -1,6 +1,5 @@
 import Service from '@ember/service';
 import { tracked } from '@glimmer/tracking';
-import SockethubClient from '@sockethub/client';
 import { io } from 'socket.io-client';
 import config from 'hyperchannel/config/environment';
 
@@ -9,22 +8,22 @@ export default class SockethubService extends Service {
   _platformContextMap = new Map();
 
   async initialize () {
+    await this._loadClientScript();
     const socket = io(config.sockethubURL, { path: '/sockethub' });
-    const client = new SockethubClient(socket);
-
-    // Downgrade client-side validation errors to warnings to facilitate live testing of unreleased/custom schemas
-    const originalValidate = client.validateActivity.bind(client);
-    client.validateActivity = function (activity) {
-      const error = originalValidate(activity);
-      if (error) {
-        console.warn('[sockethub-client] Bypassing schema validation error:', error, activity);
-      }
-      return '';
-    };
-
+    const client = new window.SockethubClient(socket);
     await client.ready();
     this.client = client;
     this._buildPlatformContextMap();
+  }
+
+  _loadClientScript () {
+    return new Promise((resolve, reject) => {
+      const script = document.createElement('script');
+      script.src = `${config.sockethubURL}/sockethub-client.js`;
+      script.onload = resolve;
+      script.onerror = () => reject(new Error(`Failed to load sockethub client from ${script.src}`));
+      document.head.appendChild(script);
+    });
   }
 
   /**

--- a/app/types/globals.d.ts
+++ b/app/types/globals.d.ts
@@ -1,0 +1,12 @@
+import type SockethubClient from '@sockethub/client';
+
+// The sockethub client bundle is loaded at runtime from the server
+// (sockethub.js service, _loadClientScript) so that the client-side
+// schema validation always matches the running server's version.
+// This declaration gives the editor the correct type for window.SockethubClient
+// using the npm package as a type source only.
+declare global {
+  interface Window {
+    SockethubClient: typeof SockethubClient;
+  }
+}

--- a/app/types/globals.d.ts
+++ b/app/types/globals.d.ts
@@ -1,12 +1,13 @@
 import type SockethubClient from '@sockethub/client';
+import type { ManagerOptions, Socket, SocketOptions } from 'socket.io-client';
 
-// The sockethub client bundle is loaded at runtime from the server
-// (sockethub.js service, _loadClientScript) so that the client-side
-// schema validation always matches the running server's version.
-// This declaration gives the editor the correct type for window.SockethubClient
-// using the npm package as a type source only.
+// Both socket.io and the sockethub client bundle are loaded at runtime from the
+// server (sockethub.js service, _loadSockethubLibs) so that the versions always
+// match the running server. These declarations give the editor correct types for
+// window.io and window.SockethubClient using the npm packages as type sources only.
 declare global {
   interface Window {
+    io: (url: string, opts?: Partial<ManagerOptions & SocketOptions>) => Socket;
     SockethubClient: typeof SockethubClient;
   }
 }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -43,7 +43,7 @@ export default [
    * https://eslint.org/docs/latest/use/configure/ignore
    */
   {
-    ignores: ['dist/', 'release/', 'node_modules/', 'coverage/', '!**/.*'],
+    ignores: ['dist/', 'release/', 'node_modules/', 'coverage/', '!**/.*', '**/*.d.ts'],
   },
   /**
    * https://eslint.org/docs/latest/use/configure/configuration-files#configuring-linter-options


### PR DESCRIPTION
## Summary

The sockethub server already serves its own pre-built client bundle at `/sockethub-client.js`. This bundle is built from the same codebase as the running server, so it always includes whatever object types the server supports.

Previously, hyperchannel installed `@sockethub/client` from npm and monkey-patched `validateActivity()` to bypass client-side schema validation. The bypass was necessary because the npm package's compiled schemas can lag behind the server when new object types are added (e.g. `room-info` in #308).

This PR instead loads the client bundle from the server at startup. The bundle sets `window.SockethubClient`, which is used to construct the client instance. This means the client-side schema validation always reflects the server's actual schema state — no bypass required.

The `@sockethub/client` npm package can be removed from `package.json` as a follow-up once anything else depending on it is audited.

## Test plan

- [x] Connect to a local sockethub server and confirm the app initialises correctly
- [x] Verify `window.SockethubClient` is set after the script loads
- [x] Confirm room-info queries work without any validation bypass