### PR TITLE
Update for Sockethub PR1088

### DIFF
--- a/sockethub.config.json
+++ b/sockethub.config.json
@@ -1,9 +1,4 @@
 {
-  "activity-streams": {
-    "opts": {
-      "specialObjs": [ "credentials" ]
-    }
-  },
   "examples": {
     "enabled": false,
     "secret": 1234567890
@@ -13,7 +8,9 @@
     "host": "localhost",
     "path": "/sockethub"
   },
-  "log_file": "",
+  "logging": {
+    "file":""
+  },
   "platforms": [
     "@sockethub/platform-irc",
     "@sockethub/platform-xmpp"
@@ -25,7 +22,6 @@
     "path": "/"
   },
   "redis": {
-    "host": "127.0.0.1",
-    "port": 6379
+    "url": "redis://127.0.0.1:6379"
   }
 }


### PR DESCRIPTION
Luckily Hyperchannel didn't make use of the activity stream tooling helpers that had been provided, there was no code that needed to be updated. This PR just brings the config inline with the current structure.
ref: https://github.com/sockethub/sockethub/pull/1088
