### PR TITLE
Fix IRC attendance query resulting in name/presence flood

### DIFF
--- a/app/services/sockethub-irc.js
+++ b/app/services/sockethub-irc.js
@@ -228,7 +228,7 @@ export default class SockethubIrcService extends Service {
   queryAttendance (channel) {
     let msg = this.buildActivityObject(channel.account, {
       type: 'query',
-      target: { id: channel.sockethubChannelId, type: 'room' },
+      target: { id: channel.sockethubChannelId, type: 'room', name: channel.name },
       object: {
         type: 'attendance'
       }


### PR DESCRIPTION
## Summary

On IRC, `queryAttendance` sent a Sockethub `query`/`attendance` job whose `target` had only an `id` and no `name`. The Sockethub IRC platform builds the `NAMES` command from `target.name`, so the omission produced a bare `NAMES` (no channel argument). IRC servers answer a bare `NAMES` with the entire network channel list, flooding the connection with presence for every channel on every join.

This sets `name` on the attendance target, mirroring what `join` already does.

Closes #312
Refs sockethub/sockethub#1085