### PR TITLE
Remove XMPP attendance query on join

### DIFF
--- a/app/services/sockethub-xmpp.js
+++ b/app/services/sockethub-xmpp.js
@@ -185,7 +185,6 @@ export default class SockethubXmppService extends Service {
           channel.addUser(username);
         }
       }
-    } else {
     }
     this.log('xmpp', 'Presence update:', message.actor.id, message.object.presence, message.object.status);
   }

--- a/app/services/sockethub-xmpp.js
+++ b/app/services/sockethub-xmpp.js
@@ -117,7 +117,6 @@ export default class SockethubXmppService extends Service {
     const channelId = message.target.id.split('/')[0];
     const channel = this.coms.channels.find(ch => ch.sockethubChannelId === channelId);
     if (channel) {
-      this.queryAttendance(channel);
       this.queryRoomInfo(channel);
     } else {
       console.warn('Could not find channel for join message', message);
@@ -187,8 +186,8 @@ export default class SockethubXmppService extends Service {
         }
       }
     } else {
-      this.log('xmpp', 'Presence update:', message.actor.id, message.object.presence, message.object.status);
     }
+    this.log('xmpp', 'Presence update:', message.actor.id, message.object.presence, message.object.status);
   }
 
   /**
@@ -225,28 +224,6 @@ export default class SockethubXmppService extends Service {
         }
       });
     }
-  }
-
-  /**
-   * Ask for a channel's attendance list (users currently joined)
-   *
-   * @param {Channel} channel
-   * @public
-   */
-  queryAttendance (channel) {
-    let msg = this.buildActivityObject(channel.account, {
-      type: 'query',
-      target: {
-        id: channel.sockethubChannelId,
-        type: 'room'
-      },
-      object: {
-        type: 'attendance'
-      }
-    });
-
-    this.log('xmpp', 'asking for attendance list', msg);
-    this.sockethubClient.socket.emit('message', msg);
   }
 
   /**


### PR DESCRIPTION
It never actually worked. Channel presence is received automatically and asynchronously when joining a channel (i.e. announcing one's presence to a channel).

Explicit attendance queries only work for admins, and aren't meant for normal users. They can be used e.g. for admin dashboards and moderation tools.